### PR TITLE
lint: typo

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         pip install .
 
-    - name: Integratoin Tests
+    - name: Integration Tests
       run: |
         pytest --no-cov tests
 


### PR DESCRIPTION
fix a typo in the ci/cd config