### PR TITLE
docs: Remove unused RELEASE.rst reference

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -11,14 +11,6 @@ All previous releases should still be available
 BatConf 0.x
 ==============
 
-.. only:: has_release_file
-
-    --------------------
-    Current pull request
-    --------------------
-
-    .. include:: ../RELEASE.rst
-
 .. _v0.1.8:
 
 --------------------


### PR DESCRIPTION
Fixes: #56

Remove some boilerplate from the release documentation, which was not being used.