### PR TITLE
add path to Configuration class

### DIFF
--- a/batconf/sources/dataclass.py
+++ b/batconf/sources/dataclass.py
@@ -39,13 +39,15 @@ _DATA_DICT_TYPE = Dict[str, _VALUES]
 
 
 class DataclassConfig(SourceInterface):
-    def __init__(self, ConfigClass: Union[ConfigProtocol, Any]):
+    def __init__(
+        self, ConfigClass: Union[ConfigProtocol, Any], path: OpStr = None
+    ):
         """Extract default values from the Config dataclass.
         Properties without defaults are set to None.
 
         :param ConfigClass: a Config dataclass or :class:`ConfigProtocol` obj
         """
-        self._root = ConfigClass.__module__
+        self._root = path if path else ConfigClass.__module__
         self._data: _DATA_DICT_TYPE = {}
 
         for field in _fields(ConfigClass):

--- a/tests/example-legacy/legacy_test.py
+++ b/tests/example-legacy/legacy_test.py
@@ -112,7 +112,7 @@ class LibTests(TestCase):
     def test_get_config_str(t):
         t.assertRegex(
             get_config_str(),
-            r"^Root <class 'legacy.ProjectConfig'>:\n"
+            r"^legacy <class 'legacy.ProjectConfig'>:\n"
             r"    \|- submodule <class 'legacy\.submodule\.SubmoduleConfig'>:"
             r'\n'
             r'    \|    \|- sub <class'

--- a/tests/example/configuration_test.py
+++ b/tests/example/configuration_test.py
@@ -1,0 +1,55 @@
+from unittest import TestCase
+
+from dataclasses import dataclass
+
+from batconf.manager import Configuration, SourceList
+from batconf.sources.dataclass import DataclassConfig
+
+
+class FreeFormConfigTreeTests(TestCase):
+    def test_freeform_config_tree(t) -> None:
+        @dataclass
+        class Level2ConfigA:
+            value: str = 'level 2 config A value'
+
+        @dataclass
+        class Level2ConfigB:
+            value: str = 'level 2 config B value'
+
+        @dataclass
+        class Level1ConfigA:
+            l2a: Level2ConfigA
+            l2b: Level2ConfigB
+            value: str = 'level 1 config A value'
+
+        @dataclass
+        class Level1ConfigB:
+            l2a: Level2ConfigA
+            l2b: Level2ConfigB
+            value: str = 'level 1 config B value'
+
+        @dataclass
+        class RootConfig:
+            l1a: Level1ConfigA
+            l1b: Level1ConfigB
+            value: str = 'root config value'
+
+        cfg = Configuration(
+            source_list=SourceList(
+                [
+                    DataclassConfig(RootConfig, path='root'),
+                ]
+            ),
+            config_class=RootConfig,
+            path='root',
+        )
+
+        t.assertEqual(cfg.value, 'root config value')
+        t.assertEqual(cfg.l1a.value, 'level 1 config A value')
+        t.assertEqual(cfg.l1a.l2a.value, 'level 2 config A value')
+        t.assertEqual(cfg.l1b.l2b.value, 'level 2 config B value')
+
+        t.assertIsInstance(cfg.l1a.l2a, Configuration)
+        t.assertEqual(cfg.l1b.value, 'level 1 config B value')
+        t.assertEqual(cfg.l1b.l2a.value, 'level 2 config A value')
+        t.assertEqual(cfg.l1b.l2b.value, 'level 2 config B value')


### PR DESCRIPTION
Adds a path parameter and attribute to the Configuration class
which will be used by sub-configs to find their associated values in configuration source trees.