### PR TITLE
Add default parameters to Configuration class

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ from batconf.source import SourceList
 from batconf.sources.args import CliArgsConfig, Namespace
 from batconf.sources.env import EnvConfig
 from batconf.sources.file import FileConfig
-from batconf.sources.dataclass import DataclassConfig
 
 
 def get_config(
@@ -89,7 +88,6 @@ def get_config(
         config_file if config_file else FileConfig(
             config_file_name, config_env=config_env
         ),
-        DataclassConfig(config_class),
     ]
 
     source_list = SourceList(config_sources)

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -96,7 +96,6 @@ from batconf.source import SourceList
 from batconf.sources.args import CliArgsConfig, Namespace
 from batconf.sources.env import EnvConfig
 from batconf.sources.file import FileConfig
-from batconf.sources.dataclass import DataclassConfig
 
 
 def get_config(
@@ -115,7 +114,6 @@ def get_config(
         config_file if config_file else FileConfig(
             config_file_name, config_env=config_env
         ),
-        DataclassConfig(config_class),
     ]
 
     source_list = SourceList(config_sources)
@@ -150,11 +148,6 @@ cfg = get_config(ClientConfig)
 print(cfg.username)
 ```
 
-*Gotcha*: the `DataclassConfig` source is currently linked to the `__module__`
-Namespace of the Config classes.  For now, we recommend that Config class 
-structure mirrors your module names.  We are working on a fix to make this 
-more flexible.
-
 
 ## Usage
 
@@ -171,7 +164,6 @@ Root <class 'bat.GlobalConfig'>:
 SourceList=[
     <batconf.sources.env.EnvConfig object at 0x7faf102ed4f0>,
     <batconf.sources.file.FileConfig object at 0x7faf102e7440>,
-    <batconf.sources.dataclass.DataclassConfig object at 0x7faf102e7740>,
 ]
 
 In [3]: cfg.server.host

--- a/tests/example/configuration_test.py
+++ b/tests/example/configuration_test.py
@@ -3,7 +3,6 @@ from unittest import TestCase
 from dataclasses import dataclass
 
 from batconf.manager import Configuration, SourceList
-from batconf.sources.dataclass import DataclassConfig
 
 
 class FreeFormConfigTreeTests(TestCase):
@@ -32,24 +31,28 @@ class FreeFormConfigTreeTests(TestCase):
         class RootConfig:
             l1a: Level1ConfigA
             l1b: Level1ConfigB
+            nodefault: str
             value: str = 'root config value'
 
         cfg = Configuration(
-            source_list=SourceList(
-                [
-                    DataclassConfig(RootConfig, path='root'),
-                ]
-            ),
+            source_list=SourceList([]),
             config_class=RootConfig,
             path='root',
         )
 
+        t.assertIsInstance(cfg, Configuration)
         t.assertEqual(cfg.value, 'root config value')
+        t.assertIsInstance(cfg.l1a, Configuration)
         t.assertEqual(cfg.l1a.value, 'level 1 config A value')
+        t.assertIsInstance(cfg.l1a.l2a, Configuration)
         t.assertEqual(cfg.l1a.l2a.value, 'level 2 config A value')
+        t.assertIsInstance(cfg.l1a.l2a, Configuration)
         t.assertEqual(cfg.l1b.l2b.value, 'level 2 config B value')
 
         t.assertIsInstance(cfg.l1a.l2a, Configuration)
         t.assertEqual(cfg.l1b.value, 'level 1 config B value')
         t.assertEqual(cfg.l1b.l2a.value, 'level 2 config A value')
         t.assertEqual(cfg.l1b.l2b.value, 'level 2 config B value')
+
+        with t.assertRaises(AttributeError):
+            cfg.nodefault

--- a/tests/example/project/conf.py
+++ b/tests/example/project/conf.py
@@ -10,7 +10,7 @@ from batconf.source import SourceList, SourceInterface
 from batconf.sources.args import CliArgsConfig, Namespace
 from batconf.sources.env import EnvConfig
 from batconf.sources.ini import IniConfig
-from batconf.sources.dataclass import DataclassConfig
+
 
 """
 Use of a default configuration file location bears some careful consideration
@@ -64,7 +64,6 @@ def get_config(
             if config_file
             else IniConfig(config_file_name, config_env=config_env)
         ),
-        DataclassConfig(config_class),
     ]
 
     source_list = SourceList(config_sources)


### PR DESCRIPTION
Fixes: #38
    
* The Configuration class now handles default values set in Config
dataclasses.  As a result, we no longer need the DataclassConfig source
to lookup default values.
* Improve Configuration repr for paths and child-configs
* Remove DataclassConfig from example code and docs

Depends on #78 