### PR TITLE
Feature: argparse.Namespace configuration source

### DIFF
--- a/batconf/sources/argparse.py
+++ b/batconf/sources/argparse.py
@@ -1,0 +1,30 @@
+from batconf.source import SourceInterface, OpStr
+
+from argparse import Namespace
+
+
+class NamespaceConfig(SourceInterface):
+    """A configuration source
+    that retrieves values from an argparse.Namespace object.
+
+    parameters
+    ----------
+    namespace : argparse.Namespace:
+        An argparse.Namespace instance.
+
+    Examples
+    --------
+    >>> parser = argparse.ArgumentParser()
+    >>> parser.add_argument('--host', dest='root.host', default='localhost')
+    >>> args = parser.parse_args()
+    >>> config = NamespaceConfig(args)
+    >>> config.get('root.host')
+    'localhost'
+    """
+
+    def __init__(self, namespace: Namespace) -> None:
+        self._data = namespace
+
+    def get(self, key: str, module: OpStr = None) -> OpStr:
+        path = '.'.join((module, key)) if module else key
+        return getattr(self._data, path, None)

--- a/batconf/sources/args.py
+++ b/batconf/sources/args.py
@@ -4,6 +4,31 @@ from ..source import SourceInterface, OpStr
 
 
 class CliArgsConfig(SourceInterface):
+    """Legacy argparse.Namespace configuration source.
+
+    Using this source, the key value will overwrite every
+    option where the final key in its path matches.
+    project.key1, project.thing1.key1, project.thing2.key1, etc.
+    would all be set to "crash".
+
+    ex:
+    ```
+    > bat print_config key1=crash key2=override`
+    project <class 'project.cfg.ProjectConfig'>:
+        |- submodule <class 'project.submodule.SubmoduleConfig'>:
+        |    |- sub <class 'project.submodule.sub.MyClient.Config'>:
+        |    |    |- key1: "crash"
+        |    |    |- key2: "override"
+        |- clients <class 'project.cfg.ClientsSchema'>:
+        |    |- key1: "crash"
+    ```
+
+    This is often sufficient for smaller projects, where the name collisions
+    do not cause a problem,
+    and allows for simpler argparser setup where you do not need to specify
+    a 'dest=' parameter for arguments.
+    """
+
     def __init__(self, args: Namespace) -> None:
         self._data = args
 

--- a/batconf/sources/tests/argparse_test.py
+++ b/batconf/sources/tests/argparse_test.py
@@ -1,0 +1,27 @@
+from unittest import TestCase
+
+from ..argparse import NamespaceConfig, Namespace
+
+
+class TestNamespaceConfig(TestCase):
+    def test_get(t):
+        cli_args = Namespace(
+            config_file='example.config.yaml',
+            key='value',
+        )
+        setattr(cli_args, 'path.style.opt', 'path-style-option')
+        setattr(cli_args, 'bat.module.path.to.key', 'value')
+
+        cs = NamespaceConfig(cli_args)
+
+        with t.subTest('single key'):
+            t.assertEqual(cs.get('config_file'), 'example.config.yaml')
+
+        with t.subTest('path.style.key'):
+            t.assertEqual(cs.get('path.style.opt'), 'path-style-option')
+
+        with t.subTest('missing value'):
+            t.assertEqual(cs.get('missing'), None)
+
+        with t.subTest('module and key paths'):
+            t.assertEqual(cs.get('to.key', module='bat.module.path'), 'value')

--- a/tests/example/project/conf.py
+++ b/tests/example/project/conf.py
@@ -5,7 +5,9 @@ from os import path
 from batconf.manager import Configuration, ConfigProtocol
 
 from batconf.source import SourceList, SourceInterface
-from batconf.sources.args import CliArgsConfig, Namespace
+from batconf.sources.argparse import NamespaceConfig, Namespace
+
+# from batconf.sources.args import CliArgsConfig, Namespace
 from batconf.sources.env import EnvConfig
 from batconf.sources.ini import IniConfig
 from .submodule import MyClient
@@ -83,7 +85,7 @@ def get_config(
 
     # Build a prioritized config source list
     config_sources: Sequence[Optional[SourceInterface]] = [
-        CliArgsConfig(cli_args) if cli_args else None,
+        NamespaceConfig(cli_args) if cli_args else None,
         EnvConfig(),
         (
             config_file

--- a/tests/example/project/lib.py
+++ b/tests/example/project/lib.py
@@ -33,6 +33,7 @@ def configurable(func: Callable) -> Callable:
         cli_args: Optional[Namespace] = None,
         config_file_name: str = CONFIG_FILE_NAME,
         config_env: Optional[str] = None,
+        **kwargs,
     ):
         # Fetch the configuration using get_config
         cfg = get_config(
@@ -41,7 +42,7 @@ def configurable(func: Callable) -> Callable:
             config_env=config_env,
         )
         # Pass the configuration as the first argument to the wrapped function
-        return func(cfg=cfg)
+        return func(cfg=cfg, **kwargs)
 
     return wrapper
 
@@ -56,9 +57,19 @@ def get_config_str(cfg: Configuration) -> str:
 
 
 @configurable
-def get_data_from_server(cfg: Configuration) -> str:
-    """Get data from Client B"""
-    my_client_config = cfg.clients.clientB
+def get_data_from_server(clientid: str, cfg: Configuration) -> str:
+    """Get data from the specified client"""
+    # get the configuration for the specified clientid from your configuration
+    my_client_config = getattr(cfg.clients, clientid)
 
     client = MyClient.from_config(my_client_config)
     return client.fetch_data()
+
+
+@configurable
+def get_opt(cfg: Configuration) -> str:
+    return (
+        f'cfg.opt was set to `{cfg.opt}`\n'
+        f'cfg.opt2 was set to `{cfg.opt2}`\n'
+        f'cfg.clients.ClientA.key1 was set to `{cfg.clients.clientA.key1}`'
+    )

--- a/tests/integration/argparse_test.py
+++ b/tests/integration/argparse_test.py
@@ -1,0 +1,55 @@
+from unittest import TestCase
+
+from batconf.sources.argparse import NamespaceConfig
+
+from argparse import ArgumentParser, Namespace
+
+
+def argparser(cfg_path='root'):
+    p = ArgumentParser()
+    p.add_argument('-a', dest=f'{cfg_path}.alpha')
+
+    commands = p.add_subparsers(dest='command')
+    commands.add_parser(
+        'command1',
+        parents=[command_cli(f'{cfg_path}.command1')],
+        add_help=False,
+    )
+    # reusable sub-parser for commands
+    commands.add_parser(
+        'command2',
+        parents=[command_cli(f'{cfg_path}.command2')],
+        add_help=False,
+    )
+
+    return p
+
+
+def command_cli(cfg_path: str):
+    p = ArgumentParser()
+    p.add_argument('--cmd-option', dest=f'{cfg_path}.opt')
+    return p
+
+
+class NamespaceSourceTests(TestCase):
+    def test_(t) -> None:
+        parser = argparser()
+        args = ['-a=value_a', 'command1', '--cmd-option=co1']
+        namespace: Namespace = parser.parse_args(args)  # , NestedNameSpace())
+        # check access to path.like attributes on the Namespace
+        t.assertEqual(getattr(namespace, 'root.alpha'), 'value_a')
+        t.assertEqual(getattr(namespace, 'root.command1.opt'), 'co1')
+
+        # Create a Configuration Source from an argparse Namespace
+        src = NamespaceConfig(namespace)
+        t.assertEqual(src.get('root.alpha'), 'value_a')
+        t.assertEqual(src.get('root.command1.opt'), 'co1')
+        t.assertIsNone(src.get('root.command2.opt'))
+
+        # Example using command2
+        args = ['command2', '--cmd-option=co2']
+        parser = argparser()
+        namespace = parser.parse_args(args)
+        src = NamespaceConfig(namespace)
+        t.assertIsNone(src.get('root.command1.opt'))
+        t.assertEqual(src.get('root.command2.opt'), 'co2')


### PR DESCRIPTION
Add an updated Config Source, which provides access to argparse namespaces, with fully-qualified path.key attributes.

Fixes: #67

The previous args source in batconf/sources/args.py truncates all keys to just the key value.
This implementation expects Namespace attributes to be given a full path, which matches the configuration schema: `dest='project.path.to.option'` which may be a bit clunky, and could use further refinement, but solves many of the problems described in #67