### PR TITLE
Fix typo in ini_test.py

### DIFF
--- a/batconf/sources/tests/ini_test.py
+++ b/batconf/sources/tests/ini_test.py
@@ -44,7 +44,7 @@ token = *token-str*
 
 # Include configs for 3rd party libraries
 [development.pandas]
-[development.pandas.diplay]
+[development.pandas.display]
 max_rows = 1000
 max_columns = 1000
 


### PR DESCRIPTION
Corrected 'diplay' to 'display' on line 47 of batconf/sources/tests/ini_test.py. Fixes #122.