### PR TITLE
docs: add Tidelift badge and sponsorship information

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ and microservices.
 [![Build Status](https://github.com/lundybernard/batconf/actions/workflows/tests.yml/badge.svg)](https://github.com/lundybernard/batconf/actions)
 [![Documentation Status](https://readthedocs.org/projects/batconf/badge/?version=latest)](https://batconf.readthedocs.io/en/latest/)
 [![Python](https://img.shields.io/pypi/pyversions/batconf)](https://pypi.org/pypi/batconf/)
+[![Tidelift](https://tidelift.com/badges/package/pypi/batconf)](https://tidelift.com/subscription/pkg/pypi-batconf)
 
 
 Compose structured hierarchical configurations from multiple sources.
@@ -49,6 +50,10 @@ which can be adjusted to suit your needs.
 ## Professional Support
 
 ![Tidelift Logo](docs/source/_static/Tidelift_Logos_RGB_Tidelift_Mark_On-White.png)
+BatConf participates in the Tidelift open source sustainability program.
+Organizations can support the ongoing maintenance of BatConf
+while receiving professional assurances through a Tidelift subscription.
+
 Professionally supported BatConf is now available.
 
 Tidelift gives software development teams a single source for purchasing


### PR DESCRIPTION

Fixes #124 

### Summary
This PR adds the Tidelift "Lifted!" badge to the README and includes
a short note about OSS sponsorship via Tidelift.

### Changes
- Added Tidelift badge alongside existing project badges
- Clarified open source sustainability and professional support via Tidelift

This addresses the requested good-first issue.
