### PR TITLE
Feature: file Source Classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,14 @@ dependencies = [
   See the [migration guide](https://batconf.readthedocs.io/en/latest/migration.html)
   for details.
 
+## Architecture Decision Records
+
+Significant design decisions are documented in
+[`docs/decisions/`](docs/decisions/). Start with the
+[foundational ADRs](docs/decisions/0000-foundational/) to understand the
+core philosophy, then read the per-feature groups for decisions made
+during specific refactors.
+
 ## Dev Guide
 
 ### Install dev dependencies (pytest, mypy, etc)

--- a/batconf/__init__.py
+++ b/batconf/__init__.py
@@ -38,7 +38,7 @@ from .source import SourceList
 from .sources.argparse import NamespaceConfig as NamespaceSource, Namespace
 from .sources.env import EnvConfig as EnvSource
 from .sources.ini import IniConfig as IniSource
-from .sources.toml import TomlConfig as TomlSource
+from .sources.toml import TomlSource
 from .sources.yaml import YamlConfig as YamlSource
 
 __all__ = [

--- a/batconf/__init__.py
+++ b/batconf/__init__.py
@@ -37,7 +37,7 @@ from .manager import Configuration
 from .source import SourceList
 from .sources.argparse import NamespaceConfig as NamespaceSource, Namespace
 from .sources.env import EnvConfig as EnvSource
-from .sources.ini import IniConfig as IniSource
+from .sources.ini import IniSource
 from .sources.toml import TomlSource
 from .sources.yaml import YamlConfig as YamlSource
 

--- a/batconf/__init__.py
+++ b/batconf/__init__.py
@@ -39,7 +39,7 @@ from .sources.argparse import NamespaceConfig as NamespaceSource, Namespace
 from .sources.env import EnvConfig as EnvSource
 from .sources.ini import IniSource
 from .sources.toml import TomlSource
-from .sources.yaml import YamlConfig as YamlSource
+from .sources.yaml import YamlSource
 
 __all__ = [
     # Core

--- a/batconf/sources/_compat.py
+++ b/batconf/sources/_compat.py
@@ -1,0 +1,49 @@
+"""
+Internal backwards-compatibility helpers.
+
+This module provides reusable machinery for deprecating old names within
+the batconf.sources package. It is not part of the public API.
+"""
+import warnings
+
+
+def make_deprecated_getattr(
+    deprecated: dict[str, str],
+    module_globals: dict,
+    module_name: str,
+    targets: dict[str, str] | None = None,
+):
+    """Return a module-level ``__getattr__`` that warns on deprecated names.
+
+    Parameters
+    ----------
+    deprecated : dict[str, str]
+        Mapping of old name to display name used in the warning message.
+    module_globals : dict
+        The calling module's ``globals()`` dict, used to resolve names.
+    module_name : str
+        The calling module's ``__name__``, used in ``AttributeError`` messages.
+    targets : dict[str, str], optional
+        Overrides which globals key is returned for each old name.
+        When omitted, the display name from ``deprecated`` is used as the key.
+
+    Returns
+    -------
+    Callable[[str], object]
+        A ``__getattr__`` function suitable for assignment at module level.
+    """
+    _targets = targets or {}
+
+    def __getattr__(name: str):
+        if alias := deprecated.get(name):
+            warnings.warn(
+                f'{name!r} is deprecated, use {alias!r} instead.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return module_globals[_targets.get(name, alias)]
+        raise AttributeError(
+            f'module {module_name!r} has no attribute {name!r}'
+        )
+
+    return __getattr__

--- a/batconf/sources/ini.py
+++ b/batconf/sources/ini.py
@@ -6,8 +6,6 @@ from configparser import ConfigParser
 from pathlib import Path
 from enum import Enum, auto
 
-from ..source import SourceInterface
-
 from .types import FileSourceP
 from .file import (
     ConfigFileFormats,
@@ -16,6 +14,7 @@ from .file import (
     missing_file_handlers as _missing_file_handlers,
     file_config_repr,
 )
+from ._compat import make_deprecated_getattr
 
 
 log = getLogger(__name__)
@@ -110,100 +109,6 @@ _getter_methods = {
 
 class EmptyConfigParser:
     def get(self, section: str, option: str, fallback=None) -> None: ...
-
-
-# === IniConfig Class === #
-
-
-class IniConfig(SourceInterface):
-    """Configuration source backed by an INI file.
-
-    Parameters
-    ----------
-    file_path : str
-        Path to the INI configuration file.
-    config_env : str or None, default=read from file
-        Active configuration environment. When not provided, the value of
-        ``batconf.default_env`` in the INI file is used.
-    missing_file_option : {'warn', 'ignore', 'error'}, default='warn'
-        Behaviour when the specified file is missing.
-    file_format : {'environments', 'sections', 'flat'}, default='environments'
-        INI file layout. ``'environments'`` expects top-level sections named
-        after environments; ``'sections'`` uses sections as config namespaces;
-        ``'flat'`` reads all keys from a single ``[root]`` section.
-
-    Examples
-    --------
-    >>> src = IniSource(file_path='config.ini', config_env='dev')
-    """
-
-    _data: ConfigParser | EmptyConfigParser = EmptyConfigParser()
-    _get_impl: Callable
-    __config_env: str
-
-    def __init__(
-        self,
-        file_path: str,
-        config_env: _EnvOpts = _DEFAULTS.environment,
-        missing_file_option: _MissingFileOption = 'warn',
-        file_format: ConfigFileFormats = 'environments',
-    ):
-        self._missing_file_option = missing_file_option
-        self._file_format = file_format
-        self._config_file_path = Path(file_path)
-
-        self._data = _load_ini(
-            file_path=self._config_file_path,
-            file_format=self._file_format,
-            when_missing=self._missing_file_option,
-        )
-
-        self._config_env = config_env  # type: ignore[assignment]
-        # This mypy error will be fixed by
-        # https://github.com/python/mypy/pull/18510
-
-        if self._data is EmptyConfigParser:
-            self._get_impl = _getter_methods['empty']
-        else:
-            try:
-                self._get_impl = _getter_methods[file_format]
-            except KeyError:
-                raise ValueError(f'Invalid file_format: {file_format}')
-
-    def get(self, key: str, path: str | None = None) -> str | None:
-        # TODO: fully deprecate the path parameter
-        return self._get_impl(self, key=key, path=path)
-
-    # TODO: Fix type-hints when the next version of MyPy is released
-    @property
-    def _config_env(self):  # -> str:
-        return self.__config_env
-
-    @_config_env.setter
-    def _config_env(self, env):  # _EnvOpts):
-        if (
-            self._file_format != 'environments'
-            or self._data is EmptyConfigParser
-        ):
-            self.__config_env = None  # type: ignore[assignment]
-            return
-
-        if env is _DEFAULTS.environment or env is None:
-            # use the batconf.default_env value from the config file
-            self.__config_env = self._data.get('batconf', 'default_env')
-        else:
-            self.__config_env = env
-
-        if not self._data.has_section(self._config_env):
-            raise ValueError(
-                f'Config Environment "{self._config_env}" '
-                f'not found in {self._config_file_path}'
-            )
-
-    def __str__(self):
-        return f'Ini File: {repr(self)}'
-
-    __repr__ = file_config_repr
 
 
 class IniSource(FileSourceP):
@@ -305,6 +210,52 @@ class IniSource(FileSourceP):
         return f'Ini File: {repr(self)}'
 
     __repr__ = file_config_repr
+
+
+# === IniConfig (deprecated) === #
+
+
+class IniConfig(IniSource):
+    """Deprecated. Use IniSource instead.
+
+    Parameters
+    ----------
+    file_path : str
+        Path to the INI configuration file.
+    config_env : str or None, default=read from file
+        Active configuration environment. When not provided, the value of
+        ``batconf.default_env`` in the INI file is used.
+    missing_file_option : {'warn', 'ignore', 'error'}, default='warn'
+        Behaviour when the specified file is missing.
+    file_format : {'environments', 'sections', 'flat'}, default='environments'
+        INI file layout.
+    """
+
+    def __init__(
+        self,
+        file_path: str,
+        config_env: _EnvOpts = _DEFAULTS.environment,
+        missing_file_option: _MissingFileOption = 'warn',
+        file_format: ConfigFileFormats = 'environments',
+    ):
+        env = None if config_env is _DEFAULTS.environment else config_env
+        super().__init__(
+            file_path=file_path,
+            file_format=file_format,
+            config_env=env,
+            missing_file_option=missing_file_option,
+        )
+
+
+_IniConfig = IniConfig
+del IniConfig
+
+__getattr__ = make_deprecated_getattr(
+    deprecated={'IniConfig': 'IniSource'},
+    module_globals=globals(),
+    module_name=__name__,
+    targets={'IniConfig': '_IniConfig'},
+)
 
 
 # === INI File Loader Functions === #

--- a/batconf/sources/ini.py
+++ b/batconf/sources/ini.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 from typing import Literal, Protocol, Callable
 from logging import getLogger
 
@@ -7,6 +8,7 @@ from enum import Enum, auto
 
 from ..source import SourceInterface
 
+from .types import FileSourceP
 from .file import (
     ConfigFileFormats,
     _MissingFileOption,
@@ -197,6 +199,107 @@ class IniConfig(SourceInterface):
                 f'Config Environment "{self._config_env}" '
                 f'not found in {self._config_file_path}'
             )
+
+    def __str__(self):
+        return f'Ini File: {repr(self)}'
+
+    __repr__ = file_config_repr
+
+
+class IniSource(FileSourceP):
+    """Configuration source backed by an INI file.
+
+    Parameters
+    ----------
+    file_path : str
+        Path to the INI configuration file.
+    file_format : {'environments', 'sections', 'flat'}, default='environments'
+        INI file layout. ``'environments'`` expects top-level sections named
+        after environments; ``'sections'`` uses sections as config namespaces;
+        ``'flat'`` reads all keys from a single ``[root]`` section.
+    config_env : str or None, default=read from file
+        Active configuration environment. When not provided, the value of
+        ``batconf.default_env`` in the INI file is used.
+    missing_file_option : {'warn', 'ignore', 'error'}, default='warn'
+        Behaviour when the specified file is missing.
+
+    Examples
+    --------
+    >>> src = IniSource(file_path='config.ini', config_env='dev')
+    """
+
+    def __init__(
+        self,
+        file_path: str,
+        file_format: ConfigFileFormats = 'environments',
+        config_env: str | None = None,
+        missing_file_option: _MissingFileOption = 'warn',
+    ):
+        self._missing_file_option = missing_file_option
+        self._file_format = file_format  # validated by setter
+        self._config_file_path = Path(file_path)
+        self._config_env = config_env  # type: ignore[assignment]
+
+    def get(self, key: str, path: str | None = None) -> str | None:
+        return self._get_impl(self, key=key, path=path)
+
+    @property
+    def _file_format(self) -> str:
+        return self.__file_format
+
+    @_file_format.setter
+    def _file_format(self, fmt: str) -> None:
+        if fmt not in _file_type_loaders:
+            raise ValueError(f'Invalid file_format: {fmt}')
+        self.__file_format = fmt
+
+    @property
+    def _loader(self):
+        return _file_type_loaders[self._file_format]
+
+    @property
+    def _get_impl(self):
+        if self._data is EmptyConfigParser:
+            return _getter_methods['empty']
+        return _getter_methods[self._file_format]
+
+    @cached_property
+    def _raw_data(self):
+        return _load_ini(
+            file_path=self._config_file_path,
+            file_format=self._file_format,
+            when_missing=self._missing_file_option,
+        )
+
+    @cached_property
+    def _data(self):
+        if self._raw_data is EmptyConfigParser:
+            return self._raw_data
+        if self._file_format == 'environments':
+            if not self._raw_data.has_section(self._config_env):
+                raise ValueError(
+                    f'Config Environment "{self._config_env}" '
+                    f'not found in {self._config_file_path}'
+                )
+        return self._raw_data
+
+    # TODO: Fix type-hints when the next version of MyPy is released
+    @property
+    def _config_env(self):  # -> str | None:
+        if self._file_format != 'environments':
+            return None
+        if self.__config_env is None:
+            raw = self._raw_data
+            if raw is not EmptyConfigParser:
+                self.__config_env = raw.get('batconf', 'default_env')
+        return self.__config_env
+
+    @_config_env.setter
+    def _config_env(self, env):  # str | None
+        if not self._file_format == 'environments':
+            self.__config_env = None  # type: ignore[assignment]
+            return
+        self.__config_env = env
 
     def __str__(self):
         return f'Ini File: {repr(self)}'

--- a/batconf/sources/tests/_compat_test.py
+++ b/batconf/sources/tests/_compat_test.py
@@ -1,0 +1,68 @@
+import warnings
+from unittest import TestCase
+from unittest.mock import sentinel
+
+from .._compat import make_deprecated_getattr
+
+
+SRC = 'batconf.sources._compat'
+
+
+class MakeDeprecatedGetAttrTests(TestCase):
+    def setUp(t):
+        t.module_globals = {'NewName': sentinel.NewClass}
+        t.module_name = 'batconf.sources.somemodule'
+        t.deprecated = {'OldName': 'NewName'}
+
+        t.dga = make_deprecated_getattr(
+            deprecated=t.deprecated,
+            module_globals=t.module_globals,
+            module_name=t.module_name,
+        )
+
+    def test_returns_new_class(t):
+        with warnings.catch_warnings(record=True):
+            result = t.dga('OldName')
+        t.assertIs(result, sentinel.NewClass)
+
+    def test_emits_deprecation_warning(t):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            t.dga('OldName')
+        t.assertIs(w[0].category, DeprecationWarning)
+        t.assertEqual(
+            f"'OldName' is deprecated, use 'NewName' instead.",
+            str(w[0].message)
+            )
+
+    def test_raises_attribute_error_for_unknown_name(t):
+        with t.assertRaises(AttributeError) as err:
+            t.dga('NonExistent')
+        t.assertEqual(
+            f"module '{t.module_name}' has no attribute 'NonExistent'",
+            str(err.exception)
+        )
+
+    def test_targets_returns_different_object(t):
+        """targets overrides which object is returned while keeping the
+        display name in the warning message unchanged."""
+        module_globals = {
+            'NewName': sentinel.NewClass,
+            '_LegacyClass': sentinel.LegacyClass,
+        }
+        dga = make_deprecated_getattr(
+            deprecated={'OldName': 'NewName'},
+            module_globals=module_globals,
+            module_name=t.module_name,
+            targets={'OldName': '_LegacyClass'},
+        )
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            result = dga('OldName')
+
+        t.assertIs(result, sentinel.LegacyClass)
+        t.assertEqual(
+            "'OldName' is deprecated, use 'NewName' instead.",
+            str(w[0].message),
+        )

--- a/batconf/sources/tests/ini_test.py
+++ b/batconf/sources/tests/ini_test.py
@@ -1,9 +1,10 @@
 from unittest import TestCase
-from unittest.mock import Mock, patch, mock_open, create_autospec
+from unittest.mock import Mock, patch, mock_open, create_autospec, PropertyMock
 
 from ..ini import (
     # Under Test
     IniConfig,
+    IniSource,
     ConfigFileFormats,
     _load_ini_file,
     _load_ini_file_flat,
@@ -22,7 +23,6 @@ from ..ini import (
 
 
 SRC = 'batconf.sources.ini'
-
 
 # Sample .ini data as a string
 INI_ENV_STR = """
@@ -54,7 +54,6 @@ user = Morgan B.
 user = knights
 """
 
-
 EXAMPLE_SECTIONS_STR = """
 [sec0]
 k0 = s0v0
@@ -62,13 +61,11 @@ k0 = s0v0
 k0 = s1v0
 """
 
-
 EXAMPLE_FLAT_STR = """
 k1 = v1
 key with spaces: val with spaces
 key.with.dots = val.with.dots
 """
-
 
 # Maybe removed, we are not getting an acutal dict from ConfigParser
 EXAMPLE_CONFIG_DICT: dict = {
@@ -82,7 +79,6 @@ EXAMPLE_CONFIG_DICT: dict = {
     },
     'production': {'project': {'user': 'Morgan B.'}},
 }
-
 
 CONFIG_PARSER_ENVS = ConfigParser()
 CONFIG_PARSER_ENVS.read_string(INI_ENV_STR)
@@ -263,7 +259,8 @@ class IniConfigTests(TestCase):
                 )
             t.assertEqual(
                 str(err.exception),
-                'Config Environment "MissingEnvironment" not found in testconfig.ini',
+                'Config Environment "MissingEnvironment" not found in '
+                'testconfig.ini',
             )
 
         with t.subTest('missing environments format file'):
@@ -280,12 +277,13 @@ class IniConfigTests(TestCase):
 
         # flat and sections formats set _config_env to None
         for file_format, config_parser in (
-            (ff, p)
-            for ff in ('flat', 'sections')
-            for p in (ConfigParser, EmptyConfigParser)
+                (ff, p)
+                for ff in ('flat', 'sections')
+                for p in (ConfigParser, EmptyConfigParser)
         ):
             with t.subTest(
-                f'_config_env is None when {file_format=} and {config_parser=}'
+                    f'_config_env is None when {file_format=} and '
+                    f'{config_parser=}'
             ):
                 t._load_ini.return_value = config_parser
                 ic = IniConfig(
@@ -326,6 +324,214 @@ class IniConfigTests(TestCase):
             'IniConfig(file_path=testconfig.ini, config_env=development, '
             'missing_file_option=warn, file_format=environments)',
             repr(ic),
+        )
+
+
+class IniSourceTests(TestCase):
+    _load_ini: Mock
+
+    def setUp(t):
+        patches = [
+            '_load_ini',
+        ]
+        for target in patches:
+            patcher = patch(f'{SRC}.{target}', autospec=True)
+            setattr(t, target, patcher.start())
+            t.addCleanup(patcher.stop)
+
+        t._load_ini.return_value = CONFIG_PARSER_ENVS
+
+        t.config_file_str = 'testconfig.ini'
+        t.ins = IniSource(
+            file_path=t.config_file_str,
+            # Default: file_format='environments',
+            # Default: config_env=None,
+            # Default: missing_file_option='warn',
+        )
+
+    def test___init__(t):
+        ins = IniSource(
+            file_path=t.config_file_str,
+            # Default: file_format='environments',
+            # Default: config_env=None,
+            # Default: missing_file_option='warn',
+        )
+
+        t.assertEqual(ins._file_format, 'environments')
+        t.assertEqual(ins._missing_file_option, 'warn')
+        t.assertEqual(ins._config_file_path, Path(t.config_file_str))
+        t._load_ini.assert_not_called()  # lazy: file not read on construction
+
+        # Accessing _config_env triggers lazy load
+        t.assertEqual(ins._config_env, 'development')
+        t._load_ini.assert_called_once_with(
+            file_path=Path(t.config_file_str),
+            file_format='environments',
+            when_missing='warn',
+        )
+
+    def test___init__catches_invalid_file_format(t):
+        with t.assertRaises(ValueError):
+            _ = IniSource(file_path=t.config_file_str, file_format='invalid')
+
+    def test__file_format(t):
+        with t.subTest('valid formats stored'):
+            for fmt in ('environments', 'sections', 'flat'):
+                t.ins._file_format = fmt
+                t.assertEqual(t.ins._file_format, fmt)
+
+        with t.subTest('invalid format raises ValueError'):
+            with t.assertRaises(ValueError):
+                t.ins._file_format = 'invalid'
+
+    def test__loader(t):
+        with t.subTest('environments'):
+            t.ins._file_format = 'environments'
+            t.assertIs(t.ins._loader, _load_ini_file)
+
+        with t.subTest('sections'):
+            t.ins._file_format = 'sections'
+            t.assertIs(t.ins._loader, _load_ini_file)
+
+        with t.subTest('flat'):
+            t.ins._file_format = 'flat'
+            t.assertIs(t.ins._loader, _load_ini_file_flat)
+
+    def test__config_env(t):
+        with t.subTest('environments format: stores value'):
+            t.ins._config_env = 'production'
+            t.assertEqual(t.ins._config_env, 'production')
+
+        with t.subTest('environments format: None auto-resolves from file'):
+            t.ins._config_env = None
+            t.assertEqual(t.ins._config_env, 'development')
+
+        with t.subTest('sections format: always None'):
+            t.ins._file_format = 'sections'
+            t.ins._config_env = 'any_value'
+            t.assertIsNone(t.ins._config_env)
+
+        with t.subTest('flat format: always None'):
+            t.ins._file_format = 'flat'
+            t.ins._config_env = 'any_value'
+            t.assertIsNone(t.ins._config_env)
+
+    def test__data(t):
+        with t.subTest('calls _load_ini with correct args'):
+            ins = IniSource(file_path=t.config_file_str)
+            _ = ins._data
+            t._load_ini.assert_called_once_with(
+                file_path=Path(t.config_file_str),
+                file_format='environments',
+                when_missing='warn',
+            )
+
+        with t.subTest('caches result'):
+            t._load_ini.reset_mock()
+            ins = IniSource(file_path=t.config_file_str)
+            _ = ins._data
+            _ = ins._data
+            t._load_ini.assert_called_once()
+
+        with t.subTest(
+                'environments: returns config and resolves _config_env'
+        ):
+            ins = IniSource(file_path=t.config_file_str)
+            t.assertIs(ins._data, CONFIG_PARSER_ENVS)
+            t.assertEqual(ins._config_env, 'development')
+
+        with t.subTest('environments: raises ValueError for missing section'):
+            ins = IniSource(
+                file_path=t.config_file_str,
+                config_env='nonexistent_env',
+            )
+            with t.assertRaises(ValueError) as err:
+                _ = ins._data
+            t.assertEqual(
+                str(err.exception),
+                'Config Environment "nonexistent_env" not found in '
+                'testconfig.ini',
+            )
+
+        with t.subTest('EmptyConfigParser: clears _config_env'):
+            t._load_ini.return_value = EmptyConfigParser
+            ins = IniSource(file_path=t.config_file_str)
+            t.assertIs(ins._data, EmptyConfigParser)
+            t.assertIsNone(ins._config_env)
+
+        for option in ('warn', 'ignore', 'error'):
+            with t.subTest(f'passes when_missing={option} to _load_ini'):
+                t._load_ini.reset_mock()
+                t._load_ini.return_value = CONFIG_PARSER_ENVS
+                ins = IniSource(
+                    file_path=t.config_file_str,
+                    missing_file_option=option,
+                )
+                _ = ins._data
+                t._load_ini.assert_called_once_with(
+                    file_path=Path(t.config_file_str),
+                    file_format='environments',
+                    when_missing=option,
+                )
+
+    def test__get_impl(t):
+        with patch.object(
+                IniSource,
+                '_data',
+                new_callable=PropertyMock
+        ) as mock_data:
+            with t.subTest('EmptyConfigParser'):
+                mock_data.return_value = EmptyConfigParser
+                t.assertIs(t.ins._get_impl, _getter_methods['empty'])
+
+            with t.subTest('environments'):
+                mock_data.return_value = CONFIG_PARSER_ENVS
+                t.ins._file_format = 'environments'
+                t.assertIs(t.ins._get_impl, _getter_methods['environments'])
+
+            with t.subTest('sections'):
+                t.ins._file_format = 'sections'
+                t.assertIs(t.ins._get_impl, _getter_methods['sections'])
+
+            with t.subTest('flat'):
+                t.ins._file_format = 'flat'
+                t.assertIs(t.ins._get_impl, _getter_methods['flat'])
+
+    def test_get(t):
+        """get() delegates to _get_impl"""
+        mock_getter = Mock(return_value=Mock())
+
+        with patch.dict(f'{SRC}._getter_methods', environments=mock_getter):
+            ret = t.ins.get(key='section.key')
+        mock_getter.assert_called_with(t.ins, key='section.key', path=None)
+        t.assertIs(ret, mock_getter.return_value)
+
+        with t.subTest('path parameter'):
+            with patch.dict(
+                    f'{SRC}._getter_methods',
+                    environments=mock_getter
+            ):
+                ret = t.ins.get(key='key', path='section.sub')
+            mock_getter.assert_called_with(
+                t.ins,
+                key='key',
+                path='section.sub'
+            )
+            t.assertIs(ret, mock_getter.return_value)
+
+    def test_get_legacy_path_parameter(t):
+        ret = t.ins.get(key='token', path='project.database')
+        t.assertEqual('*token-str*', ret)
+
+    def test___str__(t) -> None:
+        t.assertEqual(f'Ini File: {repr(t.ins)}', str(t.ins))
+
+    def test___repr__(t) -> None:
+        t.ins._config_env = 'development'
+        t.assertEqual(
+            'IniSource(file_path=testconfig.ini, config_env=development, '
+            'missing_file_option=warn, file_format=environments)',
+            repr(t.ins),
         )
 
 

--- a/batconf/sources/tests/ini_test.py
+++ b/batconf/sources/tests/ini_test.py
@@ -1,9 +1,11 @@
+import warnings
+
 from unittest import TestCase
 from unittest.mock import Mock, patch, mock_open, create_autospec, PropertyMock
 
 from ..ini import (
     # Under Test
-    IniConfig,
+    _IniConfig,
     IniSource,
     ConfigFileFormats,
     _load_ini_file,
@@ -85,246 +87,16 @@ CONFIG_PARSER_ENVS.read_string(INI_ENV_STR)
 
 
 class IniConfigTests(TestCase):
-    _load_ini: Mock
+    def test_is_IniSource_subclass(t):
+        t.assertTrue(issubclass(_IniConfig, IniSource))
 
-    def setUp(t):
-        patches = [
-            '_load_ini',
-        ]
-        for target in patches:
-            patcher = patch(f'{SRC}.{target}', autospec=True)
-            setattr(t, target, patcher.start())
-            t.addCleanup(patcher.stop)
+    def test___init__(t):
+        ic = _IniConfig(file_path='test.ini')
+        t.assertIsInstance(ic, IniSource)
 
-        t._load_ini.return_value = CONFIG_PARSER_ENVS
-
-        t.config_file_str = 'testconfig.ini'
-
-    def test___init__defaults(t):
-        ic = IniConfig(
-            file_path=t.config_file_str,
-            # Default: config_env=* loads default from file
-            # Default: file_format='environments',
-            # Default: missing_file_option='warn',
-        )
-
-        t.assertEqual(ic._file_format, 'environments')
-        t.assertEqual(ic._missing_file_option, 'warn')
-        t.assertEqual(ic._config_file_path, Path(t.config_file_str))
-
-        t.assertIs(ic._data, t._load_ini.return_value)
-        config_env = CONFIG_PARSER_ENVS.get('batconf', 'default_env')
-        t.assertEqual(config_env, 'development')
-        t.assertEqual(ic._config_env, config_env)
-        t.assertIs(ic._get_impl, _getter_methods['environments'])
-
-    def test___init__catches_invalid_file_format(t):
-        with t.assertRaises(ValueError):
-            _ = IniConfig(file_path=t.config_file_str, file_format='invalid')
-
-    def test_get(t):
-        """The get method calls the expected _get_config variant"""
-        ic = IniConfig(file_path=t.config_file_str)
-        _get_config_mock = Mock(_get_envs, autospec=True)
-
-        ic._get_impl = _get_config_mock
-
-        ret = ic.get(key='section.key')
-
-        _get_config_mock.assert_called_with(ic, key='section.key', path=None)
-        t.assertIs(ret, _get_config_mock.return_value)
-
-        with t.subTest('path parameter'):
-            ret = ic.get(key='key', path='section.sub')
-            _get_config_mock.assert_called_with(
-                ic,
-                key='key',
-                path='section.sub',
-            )
-            t.assertIs(ret, _get_config_mock.return_value)
-
-    def test_get_legacy_path_parameter(t):
-        """The path parameter is expected to be deprecated in the near future,
-        but we still need it to respect how the Configuration class
-        currently handles path lookups.
-        """
-        ic = IniConfig(file_path=t.config_file_str)
-        ret = ic.get(key='token', path='project.database')
-        t.assertEqual('*token-str*', ret)
-
-    # === .ini file format options === #
-    def test_file_format_sections(t):
-        ic = IniConfig(
-            file_path=t.config_file_str,
-            file_format='sections',
-            # Default: missing_file_option='warn',
-        )
-
-        t.assertEqual(ic._file_format, 'sections')
-        # _config_env is not set for 'sections' file format
-        t.assertEqual(ic._config_env, None)
-        t.assertIs(ic._get_impl, _getter_methods['sections'])
-
-    def test_environments_format(t):
-        file_format = 'environments'
-        config_env = 'production'
-
-        ic = IniConfig(
-            file_path=t.config_file_str,
-            config_env=config_env,
-            file_format=file_format,
-        )
-
-        t.assertEqual(ic._file_format, file_format)
-        t.assertEqual(ic._config_env, config_env)
-        t.assertIs(ic._get_impl, _getter_methods[file_format])
-
-    def test_flat_format(t):
-        file_format = 'flat'
-
-        ic = IniConfig(
-            file_path=t.config_file_str,
-            file_format=file_format,
-        )
-
-        t.assertEqual(ic._file_format, file_format)
-        # _config_env is not set for 'flat' file format
-        t.assertIsNone(ic._config_env)
-        t.assertIs(ic._get_impl, _getter_methods[file_format])
-
-    # === Missing File Handling === #
-
-    def test_missing_file_options(t):
-        """
-        The IniConfig class does not handle missing files directly.
-        'warn' is passed to the _load_ini function,
-        which handles emitting the warning message
-        _data cannot be loaded, so it is replaced with an EmptyConfigParser
-        _config_env cannot be set from the config file, so it is set to None
-        """
-        t._load_ini.return_value = EmptyConfigParser
-
-        for option in ('warn', 'ignore', 'error'):
-            with t.subTest(f'missing_file_option={option}'):
-                ic = IniConfig(
-                    file_path=t.config_file_str,
-                    missing_file_option=option,
-                )
-
-                t._load_ini.assert_called_with(
-                    file_path=Path(t.config_file_str),
-                    file_format='environments',
-                    when_missing=option,
-                )
-                t.assertIs(ic._data, EmptyConfigParser)
-                t.assertIsNone(ic._config_env)
-
-    def test_config_env_argument(t):
-        """Validate and set the config_env parameter
-        Code Smell: there's a log of complexity here, may need refactoring
-        """
-        config_env = 'production'
-
-        with t.subTest('default environments file format'):
-            """If the config_env is not specified,
-            extract it from the configuration file
-            """
-            ic = IniConfig(
-                file_path=t.config_file_str,
-                file_format='environments',
-            )
-            t.assertEqual(
-                ic._config_env,
-                CONFIG_PARSER_ENVS.get('batconf', 'default_env'),
-            )
-
-        with t.subTest('environments file format'):
-            """Given a config_env, when the file format is 'environments',
-            save the given environment
-            """
-            ic = IniConfig(
-                file_path=t.config_file_str,
-                config_env=config_env,
-            )
-            t.assertEqual(ic._config_env, config_env)
-
-        with t.subTest('config_env section missing from file'):
-            """raise a Value Error 
-            when the specified section is not in the config file
-            """
-            with t.assertRaises(ValueError) as err:
-                _ = IniConfig(
-                    file_path=t.config_file_str,
-                    config_env='MissingEnvironment',
-                )
-            t.assertEqual(
-                str(err.exception),
-                'Config Environment "MissingEnvironment" not found in '
-                'testconfig.ini',
-            )
-
-        with t.subTest('missing environments format file'):
-            """When the ini file is not found
-            set _config_env to None
-            """
-            t._load_ini.return_value = EmptyConfigParser
-            ic = IniConfig(
-                file_path=t.config_file_str,
-                config_env=config_env,
-                file_format='environments',
-            )
-            t.assertIsNone(ic._config_env)
-
-        # flat and sections formats set _config_env to None
-        for file_format, config_parser in (
-                (ff, p)
-                for ff in ('flat', 'sections')
-                for p in (ConfigParser, EmptyConfigParser)
-        ):
-            with t.subTest(
-                    f'_config_env is None when {file_format=} and '
-                    f'{config_parser=}'
-            ):
-                t._load_ini.return_value = config_parser
-                ic = IniConfig(
-                    file_path=t.config_file_str,
-                    file_format=file_format,
-                )
-                t.assertIsNone(ic._config_env)
-
-    def test_get_methods_for_file_formats(t) -> None:
-        formats: list[ConfigFileFormats] = [
-            'flat',
-            'sections',
-            'environments',
-        ]
-        for fmt in formats:
-            with t.subTest(f'get_impl for {fmt}'):
-                ic = IniConfig(
-                    file_path=t.config_file_str,
-                    file_format=fmt,
-                )
-                t.assertIs(ic._get_impl, _getter_methods[fmt])
-
-    def test___str__(t) -> None:
-        ic = IniConfig(
-            file_path=t.config_file_str,
-            # Default: config_env=* loads default from file
-            # Default: file_format='environments',
-            # Default: missing_file_option='warn',
-        )
-        t.assertEqual(
-            f'Ini File: {repr(ic)}',
-            str(ic),
-        )
-
-    def test___repr__(t) -> None:
-        ic = IniConfig(file_path=t.config_file_str)
-        t.assertEqual(
-            'IniConfig(file_path=testconfig.ini, config_env=development, '
-            'missing_file_option=warn, file_format=environments)',
-            repr(ic),
-        )
+    def test___init___with_config_env(t):
+        ic = _IniConfig(file_path='test.ini', config_env='production')
+        t.assertEqual(ic._IniSource__config_env, 'production')
 
 
 class IniSourceTests(TestCase):
@@ -537,7 +309,7 @@ class IniSourceTests(TestCase):
 
 class GetConfigFunctionsTests(TestCase):
     def setUp(t):
-        t.ic = Mock(IniConfig, autospec=True)
+        t.ic = Mock(_IniConfig, autospec=True)
         t.ic._config_env = 'testing'
         t.key = 'key'
 

--- a/batconf/sources/tests/toml_test.py
+++ b/batconf/sources/tests/toml_test.py
@@ -1,10 +1,19 @@
 from unittest import TestCase
-from unittest.mock import patch, mock_open, Mock, MagicMock, create_autospec, sentinel
+from unittest.mock import (
+    patch,
+    mock_open,
+    Mock,
+    MagicMock,
+    create_autospec,
+    sentinel,
+)
 
 from pathlib import Path as _PathClass
 
+import warnings
+
 from ..toml import (
-    TomlConfig,
+    TomlSource,
     EmptyConfigDict,
     _load_toml,
     _load_toml_file,
@@ -12,11 +21,11 @@ from ..toml import (
     _import_toml_load_function,
     _TOML_IMPORT_ERROR_MSG,
     Path,
+    __getattr__,
 )
 
 
 SRC = 'batconf.sources.toml'
-
 
 EXAMPLE_ENVIRONMENTS_TOML = """
 [batconf]
@@ -79,8 +88,7 @@ LOAD_FLAT_DICT: dict = {'k0': 'v0', 'k1': 'v1'}
 # LOADED_FLAT_DICT = loads(EXAMPLE_FLAT_TOML)
 
 
-class TomlConfigTests(TestCase):
-    get_file_path: Mock
+class TomlSourceTests(TestCase):
     _load_toml: Mock
 
     def setUp(t):
@@ -99,116 +107,148 @@ class TomlConfigTests(TestCase):
         t.default_missing_file_option = 'warn'
 
     def test___init__defaults(t):
-        cs = TomlConfig(
+        ts = TomlSource(
             file_path=t.file_name,
             # Default: file_format='environments',
             # Default: config_env=* loads default from file
             # Default: missing_file_option='warn',
         )
 
-        t.assertEqual(cs._config_file_path, Path(t.file_name))
+        t.assertEqual(ts._config_file_path, Path(t.file_name))
         # Enable multi-environment support by default
-        t.assertEqual('environments', cs._file_format)
+        t.assertEqual('environments', ts._file_format)
 
-        t.assertEqual('test', cs._config_env)
-        t.assertEqual(t.default_missing_file_option, cs._missing_file_option)
+        t.assertEqual('test', ts._config_env)
+        t.assertEqual(t.default_missing_file_option, ts._missing_file_option)
 
-        t.assertDictEqual(cs._data, t._load_toml.return_value['test'])
+        t.assertDictEqual(ts._data, t._load_toml.return_value['test'])
         t._load_toml.assert_called_with(
-            file_path=cs._config_file_path,
+            file_path=ts._config_file_path,
             when_missing=t.default_missing_file_option,
         )
 
         # When no env is specified, select the default from the config file
         t.assertEqual(
             LOADED_ENV_DICT['batconf']['default_env'],
-            cs._config_env,
+            ts._config_env,
         )
         t.assertEqual(
             LOADED_ENV_DICT['test']['bat']['key'],
-            cs.get('bat.key'),
+            ts.get('bat.key'),
         )
 
-    def test__data_with_environments(t):
-        sc = TomlConfig(file_path=t.file_name)
-        sc._config_env = 'new_config_env'
+    def test__config_env(t):
+        with t.subTest('environments: populated from file default'):
+            ts = TomlSource(file_path=t.file_name)
+            t.assertEqual(ts._config_env, 'test')
+
+        with t.subTest('sections: always None'):
+            ts_s = TomlSource(file_path=t.file_name, file_format='sections')
+            t.assertIsNone(ts_s._config_env)
+
+        with t.subTest('flat: always None'):
+            ts_f = TomlSource(file_path=t.file_name, file_format='flat')
+            t.assertIsNone(ts_f._config_env)
+
+    def test__data(t):
+        """_raw_data is injected directly to bypass lazy file loading; tests _data's slicing logic."""
         env_cfg = {'k': 'v'}
 
-        with t.subTest('defaults'):
-            config = {sc._config_env: env_cfg}
-            sc._data = config
-            t.assertDictEqual(env_cfg, sc._data)
+        with t.subTest('environments: slices by config_env'):
+            ts = TomlSource(file_path=t.file_name)
+            ts._config_env = 'my_env'
+            ts.__dict__['_raw_data'] = {'my_env': env_cfg}
+            t.assertDictEqual(env_cfg, ts._data)
 
-        with t.subTest('defaults: missing environment'):
-            config = {'batconf': {'default_env': 'missing'}, 'v': env_cfg}
+        with t.subTest('environments: missing env raises ValueError'):
+            ts = TomlSource(file_path=t.file_name)
+            ts._config_env = 'missing'
+            ts.__dict__['_raw_data'] = {'other_env': env_cfg}
             with t.assertRaises(ValueError):
-                sc._data = config
+                _ = ts._data
 
-        with t.subTest('no config_env specified'):
-            sc._config_env = None
-            config = {'batconf': {'default_env': 'my_env'}, 'my_env': env_cfg}
-            sc._data = config
-            t.assertDictEqual(env_cfg, sc._data)
+        with t.subTest(
+            'environments: reads default_env from file when not set'
+        ):
+            ts = TomlSource(file_path=t.file_name)
+            ts.__dict__['_raw_data'] = {
+                'batconf': {'default_env': 'my_env'},
+                'my_env': env_cfg,
+            }
+            t.assertDictEqual(env_cfg, ts._data)
 
-    def test__data_with_sections(t):
-        sc = TomlConfig(file_path=t.file_name, file_format='sections')
-        sec_config = {'section0': {'k0': 'v0'}, 'section9': {'k9': 'v9'}}
-        sc._data = sec_config
+        with t.subTest('sections: returns raw dict'):
+            ts = TomlSource(file_path=t.file_name, file_format='sections')
+            sec_config = {'section0': {'k0': 'v0'}, 'section9': {'k9': 'v9'}}
+            ts.__dict__['_raw_data'] = sec_config
+            t.assertIs(sec_config, ts._data)
 
-        t.assertIs(sec_config, sc._data)
+        with t.subTest('flat: returns raw dict'):
+            ts = TomlSource(file_path=t.file_name, file_format='flat')
+            flat_config = {'k0': 'v0', 'k9': 'v9'}
+            ts.__dict__['_raw_data'] = flat_config
+            t.assertIs(flat_config, ts._data)
 
-    def test__data_with_flat_format(t):
-        sc = TomlConfig(file_path=t.file_name, file_format='flat')
-        flat_config = {'k0': 'v0', 'k9': 'v9'}
-
-        sc._data = flat_config
-
-        t.assertIs(sc._data, flat_config)
+        with t.subTest('EmptyConfigDict: returned as-is'):
+            ts = TomlSource(file_path=t.file_name)
+            ts.__dict__['_raw_data'] = EmptyConfigDict
+            t.assertIs(EmptyConfigDict, ts._data)
 
     def test_get(t):
         """Trying to get a section value returns None, not a dict"""
-        sc = TomlConfig(file_path=t.file_name)
+        ts = TomlSource(file_path=t.file_name)
 
-        t.assertIsNone(sc.get('bat'))
-        t.assertIsNone(sc.get('bat.dict'))
+        t.assertIsNone(ts.get('bat'))
+        t.assertIsNone(ts.get('bat.dict'))
 
     def test_get__from_env(t) -> None:
-        conf = TomlConfig(file_path=t.file_name)
+        ts = TomlSource(file_path=t.file_name)
 
         with t.subTest('single key'):
             t.assertEqual(
-                conf.get('bat.key'),
+                ts.get('bat.key'),
                 LOADED_ENV_DICT['test']['bat']['key'],
             )
 
         with t.subTest('key from module'):
             t.assertEqual(
-                conf.get('api_key', path='bat.remote_host'),
+                ts.get('api_key', path='bat.remote_host'),
                 LOADED_ENV_DICT['test']['bat']['remote_host']['api_key'],
             )
         with t.subTest('missing item'):
-            t.assertEqual(conf.get('_sir_not_appearing_in_this_film'), None)
+            t.assertEqual(ts.get('_sir_not_appearing_in_this_film'), None)
+
+        with t.subTest(
+            'navigating past a leaf value returns None and logs warning'
+        ):
+            with t.assertLogs(SRC, level='WARNING') as log:
+                result = ts.get('nonexistent', path='bat.key')
+            t.assertIsNone(result)
+            t.assertEqual(
+                log.records[0].getMessage(),
+                'Config path bat.key.nonexistent does not exist',
+            )
 
     def test_get__from_sections(t):
-        sc = TomlConfig(file_path=t.file_name, file_format='sections')
+        ts = TomlSource(file_path=t.file_name, file_format='sections')
+        ts.__dict__['_raw_data'] = LOAD_SEC_DICT
 
         with t.subTest('defaults'):
-            sc._data = LOAD_SEC_DICT
-            t.assertEqual(sc.get('section7.k7'), 'v7')
-            t.assertEqual(sc.get('section9.k9'), 'v9')
-            t.assertEqual(sc.get('root_key'), 'root value')
+            t.assertEqual(ts.get('section7.k7'), 'v7')
+            t.assertEqual(ts.get('section9.k9'), 'v9')
+            t.assertEqual(ts.get('root_key'), 'root value')
 
         with t.subTest('missing section returns None'):
-            t.assertIsNone(sc.get('section10'))
+            t.assertIsNone(ts.get('section10'))
 
         with t.subTest('missing key returns None'):
-            t.assertIsNone(sc.get('section0.k10'))
+            t.assertIsNone(ts.get('section0.k10'))
 
     def test_config_env_argument(t):
-        cs = TomlConfig('./example.config.toml', config_env='alt')
+        ts = TomlSource('./example.config.toml', config_env='alt')
         t.assertEqual(
             LOADED_ENV_DICT['alt']['bat']['module']['key'],
-            cs.get('key', path='bat.module'),
+            ts.get('key', path='bat.module'),
         )
 
     def test_missing_file_warning(t):
@@ -218,30 +258,39 @@ class TomlConfigTests(TestCase):
         """
         t._load_toml.return_value = EmptyConfigDict
 
-        cs = TomlConfig(file_path=t.file_name, missing_file_option='warn')
+        ts = TomlSource(file_path=t.file_name, missing_file_option='warn')
+        t._load_toml.assert_not_called()
 
+        t.assertIs(EmptyConfigDict, ts._data)
         t._load_toml.assert_called_with(
-            file_path=cs._config_file_path,
+            file_path=ts._config_file_path,
             when_missing='warn',
         )
-        t.assertIs(EmptyConfigDict, cs._data)
-        t.assertIsNone(cs.get('bat.key'))
+        t.assertIsNone(ts.get('bat.key'))
 
     def test_keys(t):
-        sc = TomlConfig(file_path=t.file_name)
-        t.assertEqual(sc.keys(), {'bat': None}.keys())
+        ts = TomlSource(file_path=t.file_name)
+        t.assertEqual(ts.keys(), ['bat'])
 
     def test___str__(t) -> None:
-        cs = TomlConfig(file_path=t.file_name)
-        t.assertEqual(f'Toml File: {repr(cs)}', str(cs))
+        ts = TomlSource(file_path=t.file_name)
+        t.assertEqual(f'Toml File: {repr(ts)}', str(ts))
 
     def test___repr__(t) -> None:
-        cs = TomlConfig(file_path=t.file_name)
+        ts = TomlSource(file_path=t.file_name)
         t.assertEqual(
-            'TomlConfig(file_path=mock.config.toml, config_env=test, '
+            'TomlSource(file_path=mock.config.toml, config_env=test, '
             'missing_file_option=warn, file_format=environments)',
-            repr(cs),
+            repr(ts),
         )
+
+
+class DeprecationTests(TestCase):
+    def test_TomlConfig_is_TomlSource_subclass(t):
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            result = __getattr__('TomlConfig')
+        t.assertTrue(issubclass(result, TomlSource))
 
 
 class TomlLoaderFunctionsTests(TestCase):
@@ -342,7 +391,7 @@ class ImportTomlLoadFunctionTests(TestCase):
             with t.assertRaises(ImportError):
                 from toml import load  # type: ignore  # noqa
 
-        with t.subTest('Instantiating TomlConfig raises ImportError'):
+        with t.subTest('Instantiating TomlSource raises ImportError'):
             with t.assertRaises(ImportError) as err:
                 _ = _import_toml_load_function()
 

--- a/batconf/sources/tests/yaml_test.py
+++ b/batconf/sources/tests/yaml_test.py
@@ -1,3 +1,4 @@
+import warnings
 from unittest import TestCase
 from unittest.mock import (
     patch,
@@ -375,6 +376,25 @@ class YamlConfigTests(TestCase):
             f'file_format=environments)',
             repr(yc),
         )
+
+
+class YamlConfigDeprecationTests(TestCase):
+    def setUp(t):
+        for target in ('get_file_path', '_load_yaml'):
+            patcher = patch(f'{SRC}.{target}', autospec=True)
+            setattr(t, target, patcher.start())
+            t.addCleanup(patcher.stop)
+        t._load_yaml.return_value = EXAMPLE_CONFIG_DICT
+        t.config_file_name = 'example.config.yaml'
+
+    def test_enable_config_environments_maps_to_file_format(t):
+        yc_envs = YamlConfig(config_file_name=t.config_file_name)
+        yc_no_envs = YamlConfig(
+            config_file_name=t.config_file_name,
+            enable_config_environments=False,
+        )
+        t.assertEqual(yc_envs._file_format, 'environments')
+        t.assertEqual(yc_no_envs._file_format, 'sections')
 
 
 class get_file_pathTests(TestCase):

--- a/batconf/sources/tests/yaml_test.py
+++ b/batconf/sources/tests/yaml_test.py
@@ -11,6 +11,8 @@ from unittest.mock import (
 from pathlib import Path as _PathClass
 
 from ..yaml import (
+    YamlSource,
+    EmptyYamlConfig,
     YamlConfig,
     get_file_path,
     _load_yaml,
@@ -61,6 +63,135 @@ EXAMPLE_CONFIG_DICT: dict = {
 
 EXAMPLE_CONFIG_WITHOUT_ENV_DICT = {'bat': {'key': 'envless_value'}}
 DEFAULT_EMPTY_CONFIGFILE_DICT = {'default': 'none', 'none': {}}
+
+EXAMPLE_ENVIRONMENTS_DICT = {
+    'batconf': {'default_env': 'example'},
+    'example': {'bat': {'key': 'value', 'remote_host': {
+        'api_key': 'example_api_key', 'url': 'https://api-example.host.io/'
+    }}},
+    'alt': {'bat': {'module': {'key': 'alt_value'}}},
+}
+
+
+class YamlSourceTests(TestCase):
+    def setUp(t):
+        patcher = patch(f'{SRC}._load_yaml', autospec=True)
+        t._load_yaml = patcher.start()
+        t.addCleanup(patcher.stop)
+
+        t._load_yaml.return_value = EXAMPLE_ENVIRONMENTS_DICT
+        t.ys = YamlSource(file_path='test.yaml')
+
+    def test___init__(t):
+        t._load_yaml.assert_not_called()  # lazy: file not read on construction
+        t.assertEqual(t.ys._config_file_path, _PathClass('test.yaml'))
+        t.assertEqual(t.ys._file_format, 'environments')
+        t.assertEqual(t.ys._missing_file_option, 'warn')
+
+        # Accessing _config_env triggers lazy load
+        t.assertEqual(t.ys._config_env, 'example')
+        t._load_yaml.assert_called_once_with(
+            file_path=_PathClass('test.yaml'),
+            when_missing='warn',
+            empty_fallback=EmptyYamlConfig,
+        )
+
+    def test__data(t):
+        """_raw_data is injected directly to bypass lazy file loading; tests _data's slicing logic."""
+        with t.subTest('environments: reads batconf.default_env, extracts subtree'):
+            env_cfg = {'k': 'v'}
+            ys = YamlSource(file_path='test.yaml')
+            ys.__dict__['_raw_data'] = {
+                'batconf': {'default_env': 'test_env'},
+                'test_env': env_cfg,
+            }
+            t.assertDictEqual(env_cfg, ys._data)
+            t.assertEqual(ys._config_env, 'test_env')
+
+        with t.subTest('environments: missing env raises ValueError'):
+            ys = YamlSource(file_path='test.yaml')
+            ys.__dict__['_raw_data'] = {'batconf': {'default_env': 'missing'}}
+            with t.assertRaises(ValueError):
+                _ = ys._data
+
+        with t.subTest('sections: returns raw dict'):
+            raw = {'sec1': {'k': 'v'}}
+            ys_s = YamlSource(file_path='test.yaml', file_format='sections')
+            ys_s.__dict__['_raw_data'] = raw
+            t.assertDictEqual(raw, ys_s._data)
+
+        with t.subTest('flat: returns raw dict'):
+            raw = {'key': 'val'}
+            ys_f = YamlSource(file_path='test.yaml', file_format='flat')
+            ys_f.__dict__['_raw_data'] = raw
+            t.assertDictEqual(raw, ys_f._data)
+
+        with t.subTest('EmptyYamlConfig: stored as-is'):
+            ys5 = YamlSource(file_path='test.yaml')
+            ys5.__dict__['_raw_data'] = EmptyYamlConfig
+            t.assertIs(ys5._data, EmptyYamlConfig)
+
+    def test__config_env(t):
+        with t.subTest('environments: populated from file default'):
+            t.assertEqual(t.ys._config_env, 'example')
+
+        with t.subTest('sections: always None'):
+            t._load_yaml.return_value = {'sec': {}}
+            ys_s = YamlSource(file_path='test.yaml', file_format='sections')
+            t.assertIsNone(ys_s._config_env)
+
+        with t.subTest('flat: always None'):
+            t._load_yaml.return_value = {'k': 'v'}
+            ys_f = YamlSource(file_path='test.yaml', file_format='flat')
+            t.assertIsNone(ys_f._config_env)
+
+    def test_get(t):
+        with t.subTest('single key'):
+            t.assertEqual(t.ys.get('bat.key'), 'value')
+
+        with t.subTest('key with path'):
+            t.assertEqual(
+                t.ys.get('api_key', path='bat.remote_host'),
+                'example_api_key',
+            )
+
+        with t.subTest('missing key returns None'):
+            t.assertIsNone(t.ys.get('nonexistent'))
+
+        with t.subTest('dict node returns None'):
+            t.assertIsNone(t.ys.get('bat'))
+
+        with t.subTest('navigating past a leaf value returns None and logs warning'):
+            with t.assertLogs(SRC, level='WARNING') as log:
+                result = t.ys.get('bat.key.sub')
+            t.assertIsNone(result)
+            t.assertEqual(
+                log.records[0].getMessage(),
+                'Config path bat.key.sub does not exist',
+            )
+
+    def test_keys(t):
+        t.assertEqual(
+            EXAMPLE_ENVIRONMENTS_DICT['example'].keys(),
+            t.ys.keys(),
+        )
+
+    def test___str__(t):
+        t.assertEqual(f'Yaml File: {repr(t.ys)}', str(t.ys))
+
+    def test___repr__(t):
+        t.assertEqual(
+            f'YamlSource('
+            f'file_path={_PathClass("test.yaml")}, '
+            f'config_env=example, '
+            f'missing_file_option=warn, '
+            f'file_format=environments)',
+            repr(t.ys),
+        )
+
+    def test_config_env_argument(t):
+        ys = YamlSource(file_path='test.yaml', config_env='alt')
+        t.assertEqual(ys.get('key', path='bat.module'), 'alt_value')
 
 
 class YamlConfigTests(TestCase):

--- a/batconf/sources/toml.py
+++ b/batconf/sources/toml.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 from typing import Any
 from logging import getLogger
 
@@ -11,6 +12,7 @@ from .file import (
     file_config_repr,
 )
 from .types import FileSourceP
+from ._compat import make_deprecated_getattr
 
 
 _OptStr = str | None
@@ -23,7 +25,7 @@ class _DEFAULTS(Enum):
     environment = auto()
 
 
-class TomlConfig(FileSourceP):
+class TomlSource(FileSourceP):
     """Configuration source backed by a TOML file.
 
     Parameters
@@ -58,55 +60,51 @@ class TomlConfig(FileSourceP):
         self._config_env = config_env
         self._missing_file_option = missing_file_option
 
-        self._data = _load_toml(
+    def get(self, key: str, path: _OptStr = None) -> _OptStr:
+        parts = path.split('.') + key.split('.') if path else key.split('.')
+        conf: Any = self._data
+        try:
+            for k in parts:
+                conf = conf.get(k)
+        except AttributeError:
+            log.warning(f'Config path {".".join(parts)} does not exist')
+            return None
+        return None if isinstance(conf, dict) else conf
+
+    def keys(self) -> list[str]:
+        return list(self._data.keys())
+
+    @cached_property
+    def _raw_data(self) -> TomlDictT:
+        return _load_toml(
             file_path=self._config_file_path,
             when_missing=self._missing_file_option,
         )
 
-    def get(self, key: str, path: _OptStr = None) -> _OptStr:
-        if path:
-            pth = path.split('.') + key.split('.')
-        else:
-            pth = key.split('.')
-
-        conf = self._data
-        for k in pth:
-            if not (conf := conf.get(k)):
-                return conf
-
-        return conf if type(conf) is not dict else None
-
-    def keys(self) -> list[str]:
-        return self._data.keys()
-
-    @property
-    def _data(self):
-        return self.__data
-
-    @_data.setter
-    def _data(self, config: dict):
-        if config is EmptyConfigDict:
-            self.__data = config
-            return
+    @cached_property
+    def _data(self) -> TomlDictT:
+        if self._raw_data is EmptyConfigDict:
+            return self._raw_data
 
         if self._file_format == 'environments':
-            if not self._config_env:
-                self._config_env = config['batconf']['default_env']
-            # Load only the specified config_env from the config dict
             try:
-                self.__data = config[self._config_env]
+                return self._raw_data[self._config_env]
             except KeyError as err:
                 raise ValueError(
                     f'Config Environment "{self._config_env}" '
                     f'not found in {self._config_file_path}'
                 ) from err
 
-        else:
-            self.__data = config
+        return self._raw_data
 
     # TODO: Fix type-hints when the next version of MyPy is released
     @property
-    def _config_env(self):  # -> str:
+    def _config_env(self):  # -> str | None:
+        if self._file_format != 'environments':
+            return None
+        if self.__config_env is None:
+            if self._raw_data is not EmptyConfigDict:
+                self.__config_env = self._raw_data['batconf']['default_env']
         return self.__config_env
 
     @_config_env.setter
@@ -153,11 +151,11 @@ def _load_toml_file(file_path: Path) -> TomlDictT:
 
 def _import_toml_load_function():
     try:
-        from tomllib import loads  # type: ignore  # noqa
+        from tomllib import loads  # type: ignore[import-not-found]
     except ImportError:
         log.debug('failed to import tomllib.load, is python < v3.11')
         try:
-            from toml import loads  # type: ignore  # noqa
+            from toml import loads  # type: ignore[assignment]
         except ImportError as e:
             raise ImportError(_TOML_IMPORT_ERROR_MSG) from e
 
@@ -168,4 +166,21 @@ _TOML_IMPORT_ERROR_MSG = (
     'Failed to import toml.load,'
     ' for python < 3.11, the toml package is required.'
     ' install the optional extra batconf[toml]'
+)
+
+# === TomlConfig (deprecated) === #
+
+
+class TomlConfig(TomlSource):
+    """Deprecated. Use TomlSource instead."""
+
+
+_TomlConfig = TomlConfig
+del TomlConfig
+
+__getattr__ = make_deprecated_getattr(
+    deprecated={'TomlConfig': 'TomlSource'},
+    module_globals=globals(),
+    module_name=__name__,
+    targets={'TomlConfig': '_TomlConfig'},
 )

--- a/batconf/sources/types.py
+++ b/batconf/sources/types.py
@@ -1,6 +1,7 @@
 from typing import Literal, Protocol
 
 ConfigFileFormats = Literal['flat', 'sections', 'environments']
+FILE_FORMATS: list[ConfigFileFormats] = ['flat', 'sections', 'environments']
 MissingFileOption = Literal['ignore', 'warn', 'error']
 
 
@@ -40,6 +41,7 @@ class FileSourceP(SourceInterfaceP, Protocol):
 
 __all__ = [
     'ConfigFileFormats',
+    'FILE_FORMATS',
     'FileSourceP',
     'MissingFileOption',
     'SourceInterfaceP',

--- a/batconf/sources/yaml.py
+++ b/batconf/sources/yaml.py
@@ -14,6 +14,7 @@ from .file import (
 )
 from .types import FileSourceP, MissingFileOption as _MissingFileOption
 from ..source import SourceInterface
+from ._compat import make_deprecated_getattr
 
 
 log = getLogger(__name__)
@@ -214,6 +215,17 @@ class YamlConfig(SourceInterface):
             if not (conf := conf.get(k)):
                 return conf
         return conf
+
+
+_YamlConfig = YamlConfig
+del YamlConfig
+
+__getattr__ = make_deprecated_getattr(
+    deprecated={'YamlConfig': 'YamlSource'},
+    module_globals=globals(),
+    module_name=__name__,
+    targets={'YamlConfig': '_YamlConfig'},
+)
 
 
 _missing_config_warning = 'Config File not found'

--- a/batconf/sources/yaml.py
+++ b/batconf/sources/yaml.py
@@ -1,17 +1,119 @@
 # Postpones evaluation of type hints for compatibility
 from __future__ import annotations
+from functools import cached_property
 from typing import Any
 
-import logging as log
+from logging import getLogger
 
 from pathlib import Path
 
 from .file import (
+    ConfigFileFormats,
     file_config_repr,
     missing_file_handlers as _missing_file_handlers,
 )
-from .types import MissingFileOption as _MissingFileOption
+from .types import FileSourceP, MissingFileOption as _MissingFileOption
 from ..source import SourceInterface
+
+
+log = getLogger(__name__)
+
+EmptyYamlConfig: dict[None, None] = dict()
+
+
+class YamlSource(FileSourceP):
+    """Configuration source backed by a YAML file.
+
+    Parameters
+    ----------
+    file_path : str
+        Path to the YAML configuration file.
+    file_format : {'environments', 'sections', 'flat'}, default='environments'
+        YAML file layout. ``'environments'`` expects a ``batconf`` mapping
+        with a ``default_env`` key and per-environment top-level mappings;
+        ``'sections'`` uses top-level keys as config namespaces; ``'flat'``
+        reads all keys from the top level.
+    config_env : str or None, default=read from file
+        Active configuration environment. When not provided, the value of
+        ``batconf.default_env`` in the YAML file is used.
+    missing_file_option : {'warn', 'ignore', 'error'}, default='warn'
+        Behaviour when the specified file is missing.
+
+    Examples
+    --------
+    >>> src = YamlSource(file_path='config.yaml', config_env='dev')
+    """
+
+    def __init__(
+        self,
+        file_path: str,
+        file_format: ConfigFileFormats = 'environments',
+        config_env: str | None = None,
+        missing_file_option: _MissingFileOption = 'warn',
+    ):
+        self._missing_file_option = missing_file_option
+        self._file_format = file_format
+        self._config_file_path = Path(file_path)
+        self._config_env = config_env
+
+    @cached_property
+    def _raw_data(self) -> dict:
+        return _load_yaml(
+            file_path=self._config_file_path,
+            when_missing=self._missing_file_option,
+            empty_fallback=EmptyYamlConfig,
+        )
+
+    @cached_property
+    def _data(self) -> dict:
+        if self._raw_data is EmptyYamlConfig:
+            return self._raw_data
+        if self._file_format == 'environments':
+            try:
+                return self._raw_data[self._config_env]
+            except KeyError as err:
+                raise ValueError(
+                    f'Config Environment "{self._config_env}" '
+                    f'not found in {self._config_file_path}'
+                ) from err
+        return self._raw_data
+
+    # TODO: Fix type-hints when the next version of MyPy is released
+    @property
+    def _config_env(self):  # -> str | None:
+        if self._file_format != 'environments':
+            return None
+        if self.__config_env is None:
+            raw = self._raw_data
+            if raw is not EmptyYamlConfig:
+                self.__config_env = raw['batconf']['default_env']
+        return self.__config_env
+
+    @_config_env.setter
+    def _config_env(self, env):  # str | None
+        if self._file_format != 'environments':
+            self.__config_env = None  # type: ignore[assignment]
+            return
+        self.__config_env = env
+
+    def get(self, key: str, path: str | None = None) -> str | None:
+        parts = path.split('.') + key.split('.') if path else key.split('.')
+        conf: Any = self._data
+        try:
+            for k in parts:
+                conf = conf.get(k)
+        except AttributeError:
+            log.warning(f'Config path {".".join(parts)} does not exist')
+            return None
+        return None if isinstance(conf, dict) else conf
+
+    def keys(self):
+        return self._data.keys()
+
+    def __str__(self) -> str:
+        return f'Yaml File: {repr(self)}'
+
+    __repr__ = file_config_repr
 
 
 class YamlConfig(SourceInterface):
@@ -153,11 +255,12 @@ _empty_yaml_config: dict = {'default': 'none', 'none': {}}
 def _load_yaml(
     file_path: Path,
     when_missing: _MissingFileOption,
+    empty_fallback: Any = _empty_yaml_config,
 ) -> dict:
     return _missing_file_handlers[when_missing](
         loader_fn=_load_yaml_file,
         file_path=file_path,
-        empty_fallback=_empty_yaml_config,
+        empty_fallback=empty_fallback,
     )
 
 

--- a/batconf/types.py
+++ b/batconf/types.py
@@ -14,6 +14,7 @@ from typing import Protocol, Type, runtime_checkable
 
 from .sources.types import (
     ConfigFileFormats,
+    FILE_FORMATS,
     FileSourceP,
     MissingFileOption,
     SourceInterfaceP,
@@ -39,12 +40,13 @@ class ConfigP(Protocol):
 
 __all__ = [
     'ConfigP',
+    'ConfigFileFormats',
     'FieldP',
+    'FILE_FORMATS',
     'FileSourceP',
+    'MissingFileOption',
     'SourceInterfaceP',
     'SourceListP',
-    'ConfigFileFormats',
-    'MissingFileOption',
 ]
 
 _deprecated: dict[str, str] = {

--- a/docs/decisions/0000-foundational/01-source-list-first-wins.md
+++ b/docs/decisions/0000-foundational/01-source-list-first-wins.md
@@ -1,0 +1,80 @@
+# SourceList first-wins priority
+
+Date: 2021-06-21
+Status: Accepted
+
+## Context
+
+Multiple configuration sources are supported: CLI args, environment
+variables, config files, and dataclass defaults. A strategy is needed to
+resolve conflicts when the same key is present in more than one source.
+
+Designed explicitly for 12-factor applications, where the
+prescribed priority order is: process arguments > environment variables >
+config file > application defaults.
+
+## Decision
+
+`SourceList` holds an ordered sequence of sources and queries them in
+index order. The first source that returns a non-`None` value wins; the
+remaining sources are not consulted for that key. Sources can be added
+at any position at runtime via `SourceList.insert_source`.
+
+The canonical priority order is:
+
+1. CLI arguments (`NamespaceSource`)
+2. Environment variables (`EnvSource`)
+3. Config file (`IniSource`, `TomlSource`, `YamlSource`, or custom)
+4. Dataclass defaults (implicit; returned by `Configuration` when all
+   sources return `None`)
+
+## Options considered
+
+### Ordered first-wins (chosen)
+
+- Predictable; matches 12-factor priority order [pro]
+- Easy to reason about overrides [pro]
+- Dynamic insertion via `insert_source` is straightforward [pro]
+- A lower-priority source can never partially override a higher-priority one [con]
+
+### Deep-merge all sources
+
+- Allows partial overrides at any level [pro]
+- Complex merge semantics [con]
+- Behaviour with missing keys is ambiguous [con]
+- Hard to trace which source contributed a value [con]
+
+### Last-wins
+
+- Simple implementation [pro]
+- Inverts 12-factor order [con]
+- CLI args must be appended last, which is counter-intuitive [con]
+
+### Per-key priority rules
+
+- Fine-grained control [pro]
+- Significant complexity [con]
+- No clear use case [con]
+
+## Rationale
+
+First-wins is the simplest strategy that satisfies 12-factor design
+and is easy to explain: "earlier in the list = higher priority." It maps
+directly onto the mental model users already have from the 12-factor app spec
+(env overrides file; CLI overrides env).
+
+Dynamic insertion (`insert_source`) lets CLI args be parsed and injected
+after the initial `SourceList` is constructed — a common pattern where
+`get_config()` is called at import time and CLI args are not yet available.
+
+## Consequences
+
+- `SourceList` is the only object that knows the priority order; `Configuration`
+  and all sources are unaware of each other.
+- `None` and all other falsey values (`""`, `False`, `0`) are treated as
+  "not found" and cause the next source to be tried. This means falsey
+  non-string values cannot be stored as real config values.
+- New sources can be inserted at runtime without rebuilding the
+  `Configuration` object.
+- The default priority order matches 12-factor but is not enforced;
+  callers can construct any order they need.

--- a/docs/decisions/0000-foundational/02-dataclass-schema.md
+++ b/docs/decisions/0000-foundational/02-dataclass-schema.md
@@ -1,0 +1,70 @@
+# Dataclass as config schema
+
+Date: 2021-06-21
+Status: Accepted
+
+## Context
+
+Users need a way to declare their configuration structure:
+what keys exist, how they are nested, and what defaults apply. Several
+approaches were available.
+
+## Decision
+
+Use Python's stdlib `dataclass` as the config schema type. Config classes
+are plain dataclasses: no BatConf base class, no BatConf decorator, no
+BatConf import required in the file that defines them. The schema is a
+tree of nested dataclasses; each nested dataclass becomes a sub-namespace
+in the resolved `Configuration`.
+
+## Options considered
+
+### stdlib `dataclass` (chosen)
+
+- No BatConf imports required in schema files [pro]
+- Schema usable without BatConf [pro]
+- Nesting via composition [pro]
+- Requires `ConfigP` protocol check rather than `isinstance(x, BatConfBase)` [con]
+
+### BatConf-specific base class
+
+- Explicit type hierarchy [pro]
+- `isinstance` checks are trivial [pro]
+- Every schema file must import from BatConf [con]
+- Tight coupling makes adoption and refactoring harder [con]
+
+### TypedDict
+
+- Familiar to users of typed dicts [pro]
+- No default values [con]
+- No nesting via composition [con]
+- Requires a separate default mechanism [con]
+
+### Pydantic / attrs model
+
+- Rich validation [pro]
+- Coercion built-in [pro]
+- External dependency [con]
+- Validation semantics conflict with BatConf's string-only value contract [con]
+
+## Rationale
+
+Using stdlib `dataclass` keeps BatConf non-intrusive. A module's config
+class can be defined, tested, and used as a plain data object independently.
+This makes adoption incremental — a team can add BatConf to an existing
+project by writing a single `conf.py` without touching any existing module
+files. Config classes can also be factored out or moved between projects
+without pulling BatConf along.
+
+Defaults declared on the dataclass fields serve as the final fallback values
+in the priority chain, at zero extra cost.
+
+## Consequences
+
+- `batconf.types.ConfigP` is a structural `Protocol` (not a base class)
+  that detects config classes via `__dataclass_fields__`.
+- All batconf imports can be isolated to a single `conf.py` per module.
+- Config dataclasses are usable as plain objects in tests and in code that
+  does not use BatConf at all.
+- Validation and type coercion are out of scope; callers are responsible
+  for converting string values to the types they need.

--- a/docs/decisions/0000-foundational/03-zero-mandatory-dependencies.md
+++ b/docs/decisions/0000-foundational/03-zero-mandatory-dependencies.md
@@ -1,0 +1,68 @@
+# Zero mandatory external dependencies
+
+Date: 2022-01-01
+Status: Accepted
+
+## Context
+
+BatConf's first release bundled `pyyaml` as a hard dependency, since YAML
+was the only supported config file format. As INI and TOML support were
+added (TOML is in the stdlib as of Python 3.11), the dependency situation
+needed to be re-evaluated.
+
+Modern Python applications carry meaningful supply-chain risk from
+transitive dependencies. Each additional mandatory package is a potential
+security attack vector that every BatConf user inherits, whether or not
+they use the feature it provides.
+
+## Decision
+
+The BatConf core package has zero external runtime dependencies. All core
+functionality — `Configuration`, `SourceList`, `EnvSource`, `IniSource`,
+`TomlSource`, `NamespaceSource`, `DataclassConfig` — relies on the Python
+stdlib only. Support for formats that require third-party packages is
+provided as optional extras declared in `pyproject.toml`:
+
+- `batconf[yaml]` — adds `pyyaml` for `YamlSource`
+- `batconf[toml]` — adds `tomli` for `TomlSource` on Python ≤ 3.10
+
+## Options considered
+
+### Zero mandatory deps, optional extras (chosen)
+
+- Users pay only for what they use [pro]
+- No implicit supply-chain risk [pro]
+- YAML users must update their dependency declaration [con]
+- Slightly more complex install docs [con]
+
+### Bundle all format support
+
+- Single install line; no extras needed [pro]
+- All users inherit pyyaml even if they only use INI or TOML [con]
+- Future format deps would be forced on all users [con]
+
+### Separate packages (batconf-yaml, etc.)
+
+- Maximum isolation [pro]
+- Fragmented ecosystem [con]
+- Harder to discover and document [con]
+
+## Rationale
+
+A library with no mandatory dependencies minimizes the risk of supply-chain
+attack and maintenance burden. Users who need YAML support opt in explicitly
+and document that choice in their own `pyproject.toml`, making the
+dependency visible and auditable.
+
+This also means that for projects using only INI or TOML (Python ≥ 3.11),
+No packages beyond the stdlib are required.
+
+## Consequences
+
+- `pip install batconf` installs no third-party packages.
+- `YamlSource` is gated behind the `yaml` extra; importing it without
+  `pyyaml` installed raises an `ImportError`.
+- Projects that previously relied on BatConf to pull in `pyyaml` as a
+  transitive dependency must add `batconf[yaml]` or `pyyaml` explicitly.
+- New format sources that require external packages must be implemented as
+  optional extras, not bundled into the core.

--- a/docs/decisions/0000-foundational/04-module-path-namespace.md
+++ b/docs/decisions/0000-foundational/04-module-path-namespace.md
@@ -1,0 +1,74 @@
+# Module path as default namespace
+
+Date: 2021-06-21
+Status: Accepted
+
+## Context
+
+Config keys must be namespaced to avoid collisions when multiple modules
+contribute configuration to the same `SourceList`. A convention is needed
+for how a config class maps to a section in a config file or an ENV
+variable prefix.
+
+## Decision
+
+`Configuration` derives the root namespace for a config class from
+`config_class.__module__` when no explicit `path` is provided. Config
+file sections and ENV variable prefixes mirror the Python dotted module
+path.
+
+An explicit `path` parameter was added to `Configuration.__init__` (and
+the recommended `get_config` function signature) to allow callers to
+override the default.
+
+## Options considered
+
+### `__module__` default (chosen)
+
+- Zero configuration needed [pro]
+- Works out of the box for single-module projects [pro]
+- Config file structure is coupled to module layout [con]
+- Renaming a module requires updating config files [con]
+
+### Explicit mandatory path
+
+- Decoupled from module layout from day one [pro]
+- Every `Configuration` construction requires a path argument [con]
+- More boilerplate for simple projects [con]
+
+### Flat (no namespace)
+
+- Simplest file format [pro]
+- Key collisions across modules [con]
+- Unworkable for multi-module projects [con]
+
+## Rationale
+
+Deriving the namespace from `__module__` was the original default: it
+required no configuration and worked for simple single-application projects
+where the config structure happened to mirror the module tree.
+
+During development it became clear that tying config file
+structure to module layout is a design constraint, not a feature. A
+`SqlClient` config section should not be named by whichever package the
+class lives in — that section name belongs to the config schema, not the
+source tree. Renaming or moving a module should not require updating config
+files.
+
+The explicit `path=` parameter was added to decouple namespace from module
+layout and is the recommended approach for any project where config
+structure needs to be stable and independent of module paths. The
+`__module__` default is retained for backwards compatibility, not as the
+preferred style.
+
+## Consequences
+
+- Config file sections use dotted Python module paths
+  (e.g. `[dev.yourproject.example.client]`).
+- ENV variable names use the uppercased, underscore-joined path
+  (e.g. `YOURPROJECT_EXAMPLE_CLIENT_HOST`).
+- Renaming a Python module changes the default namespace and breaks
+  existing config files unless `path=` is used to pin it.
+- Sub-`Configuration` objects compute their path by appending the field
+  name to the parent path, so the tree structure always mirrors the
+  dataclass nesting.

--- a/docs/decisions/0000-foundational/05-multi-environment-file-format.md
+++ b/docs/decisions/0000-foundational/05-multi-environment-file-format.md
@@ -1,0 +1,94 @@
+# Multi-environment config file format
+
+Date: 2021-06-21
+Status: Accepted
+
+## Context
+
+Config files need to support multiple deployment environments (dev, staging,
+prod) without requiring separate files per environment. The file source must
+know which section to read from, and there must be a way to declare a
+default environment so that the file works out of the box with no extra
+arguments.
+
+Config keys are already namespaced by dotted module path (see
+[module-path-namespace](04-module-path-namespace.md)), so the section
+naming convention must compose with that path.
+
+## Decision
+
+The default file format (`file_format='environments'`) prefixes every
+section with an environment name:
+
+```ini
+[batconf]
+default_env = dev
+
+[dev.yourproject.example.client]
+host = localhost
+
+[prod.yourproject.example.client]
+host = 192.168.1.1
+```
+
+The active environment is resolved in this order:
+1. The `config_env` argument passed to the source constructor.
+2. The `default_env` key in the `[batconf]` section of the file.
+3. No environment prefix (flat lookup) if neither is set.
+
+Two additional formats are supported for simpler use cases:
+- `'sections'` — sections use the dotted config path directly, no environment prefix.
+- `'flat'` — a single flat key/value file with no sections.
+
+All three file sources (`IniSource`, `TomlSource`, `YamlSource`) implement
+the same three formats with identical semantics.
+
+## Options considered
+
+### Env-prefixed sections, default in file (chosen)
+
+- Single file covers all environments [pro]
+- Default env declared alongside config; self-contained [pro]
+- Switching env requires only one argument [pro]
+- INI requires empty intermediate parent sections [con]
+
+### Separate file per environment
+
+- Simple file structure [pro]
+- File-selection logic must live outside BatConf [con]
+- Values shared across envs must be duplicated or inherited separately [con]
+
+### Environment as a top-level key in a nested format
+
+- Natural in YAML/TOML [pro]
+- Does not translate to INI [con]
+- Inconsistent across formats [con]
+
+### ENV variable selects the file
+
+- Environment selection driven by deploy infrastructure [pro]
+- No in-file default needed [pro]
+- No single-file multi-env story [con]
+- Duplication across files [con]
+
+## Rationale
+
+A single file that covers all environments is easier to review and diff
+than a directory of per-environment files. Prefixing sections with the
+environment name keeps the structure visible and explicit — every section
+declares which environment it belongs to.
+
+Declaring `default_env` inside the file means the file is self-contained:
+a developer can clone the repo and run the project without setting any
+environment variables — the default is declared in the file itself.
+
+## Consequences
+
+- All three file sources share the same `file_format` parameter and the
+  same three format modes, so users can switch formats by changing the
+  source class without changing the file format argument.
+- INI files in `environments` mode require empty intermediate sections
+  (`[dev]`, `[dev.yourproject]`) due to INI parser constraints; TOML and
+  YAML do not have this requirement.
+- `config_env` can be passed at construction time (e.g. read from an ENV
+  variable) to override the `default_env` declared in the file.

--- a/docs/decisions/0000-foundational/06-string-only-values.md
+++ b/docs/decisions/0000-foundational/06-string-only-values.md
@@ -1,0 +1,73 @@
+# String-only config values
+
+Date: 2021-06-21
+Status: Accepted
+
+## Context
+
+BatConf sources are heterogeneous: CLI args, environment variables, INI
+files, TOML files, YAML files, and arbitrary user-defined sources. Each
+source has different native type capabilities. Environment variables, for
+example, can only store strings. A contract is needed for what a source's
+`get()` method may return.
+
+## Decision
+
+Every source's `get(key, path)` method must return `str | None`. `None`
+(and all other falsey values) signals "this source does not have a value
+for this key." Values are not coerced, parsed, or validated; callers receive the raw
+string and are responsible for converting it.
+
+This contract is expressed in `SourceInterfaceP`:
+
+```python
+class SourceInterfaceP(Protocol):
+    def get(self, key: str, path: str | None = None) -> str | None: ...
+```
+
+## Options considered
+
+### `str | None` only (chosen)
+
+- Sources are interchangeable [pro]
+- No type-mismatch bugs across sources [pro]
+- ENV vars are a first-class source [pro]
+- Callers must cast; `int("8080")` is boilerplate for numeric values [con]
+
+### `Any | None`
+
+- Sources can return rich types from YAML/TOML [pro]
+- ENV source can never match [con]
+- Two sources for the same key may return different types [con]
+- Comparison logic becomes undefined [con]
+
+### Typed values with coercion
+
+- Callers receive ready-to-use values [pro]
+- Requires a schema with declared types (e.g. Pydantic) [con]
+- Coercion failures raise at read time [con]
+- Significantly more complex [con]
+
+## Rationale
+
+Environment variables are a core supported source (tier-2 in the
+12-factor priority chain) and can only store strings. Requiring all
+sources to conform to `str | None` ensures that any value retrievable
+from ENV is also retrievable from any other source with identical
+semantics. This eliminates a whole class of bugs where a config value
+works in one environment (reads from a typed TOML file) but fails in
+another (reads from ENV as a string).
+
+Type conversion is a concern for the application layer, not the
+configuration layer.
+
+## Consequences
+
+- `SourceInterfaceP.get` is typed `-> str | None`.
+- Falsey non-string values (`False`, `0`, `""`) returned by a source are
+  treated as missing and cause the next source in `SourceList` to be tried.
+  If a config key genuinely needs a falsey value, it must be stored as
+  `"false"`, `"0"`, or `"none"` and the caller interprets it.
+- User-defined sources that return non-string types (e.g. a dict-backed
+  source returning an integer) will cause silent type errors at the call
+  site. The contract is documented but not enforced at runtime.

--- a/docs/decisions/0000-foundational/07-source-interface-protocol-over-abc.md
+++ b/docs/decisions/0000-foundational/07-source-interface-protocol-over-abc.md
@@ -1,0 +1,68 @@
+# Source interface: Protocol over ABC
+
+Date: 2021-06-21
+Status: Accepted
+
+## Context
+
+Users need a way to implement custom configuration sources.
+The interface contract is simple: a single `get(key, path) -> str | None`
+method. Two standard Python mechanisms exist for expressing this contract:
+`Protocol` (structural subtyping) and abstract base classes (`ABCMeta`).
+
+## Decision
+
+`SourceInterfaceP` (a `Protocol`) is the canonical interface for
+configuration sources. Custom sources are not required to inherit from
+anything — any class with a conforming `get` method satisfies the
+interface.
+
+`SourceInterface` (an `ABCMeta` subclass) also exists as a convenience
+for contributors who want explicit ABC enforcement. It is a pragmatic
+workaround introduced when mypy had difficulty inferring structural
+conformance in certain call sites. It may be removed in a future release
+once the underlying type-checker limitations are resolved.
+
+## Options considered
+
+### Protocol only (preferred)
+
+- No forced inheritance [pro]
+- Sources remain decoupled from BatConf [pro]
+- Structural typing is idiomatic Python [pro]
+- Some versions of mypy required explicit inheritance at certain call sites [con]
+
+### ABC only
+
+- Explicit; type checkers have no ambiguity [pro]
+- Forces inheritance [con]
+- Ties custom source implementations to BatConf internals [con]
+
+### Both (current state)
+
+- Unblocks type checking immediately [pro]
+- Existing subclassers are unaffected [pro]
+- Two interfaces for the same contract is confusing [con]
+- ABC creates implicit coupling [con]
+
+## Rationale
+
+The Protocol captures the intended design: any object with the right
+`get` signature is a valid source, regardless of its class hierarchy.
+This keeps custom sources loosely coupled and easy to test in isolation.
+
+The `SourceInterface` ABC was added as a pragmatic fix for specific mypy
+false positives, not as a deliberate design choice. New custom sources
+should implement `SourceInterfaceP` structurally and not subclass
+`SourceInterface`.
+
+## Consequences
+
+- `SourceInterfaceP` is the stable public type for type annotations and
+  `isinstance` checks.
+- `SourceInterface` remains available but is not part of the intended
+  long-term API.
+- When the type-checker issues are resolved, `SourceInterface` will be
+  deprecated and eventually removed.
+- Existing code that subclasses `SourceInterface` will continue to work;
+  the ABC satisfies the Protocol by structural conformance.

--- a/docs/decisions/0000-foundational/08-config-singleton.md
+++ b/docs/decisions/0000-foundational/08-config-singleton.md
@@ -1,0 +1,101 @@
+# ConfigSingleton: optional global configuration
+
+Date: 2021-06-21
+Status: Accepted
+
+## Context
+
+Many applications want to share a single configuration object across
+modules without passing it explicitly through every call site. The
+straightforward solution — a module-level global — is convenient but
+carries well-known risks: implicit coupling, test pollution, and
+difficult-to-reason-about initialization order.
+
+`Configuration` itself is stateless with respect to identity; every call
+to `get_config()` produces a fresh object. A separate mechanism is needed
+for users who want a shared singleton, without forcing singleton semantics
+on users who do not.
+
+## Decision
+
+`ConfigSingleton` is an optional lazy proxy that users may choose to
+adopt. It is not required. The intended use case is a single, global
+configuration object shared across an application:
+
+```python
+# yourmodule/conf.py
+CFG = ConfigSingleton(get_config)
+
+# anywhere else in the application
+from yourmodule.conf import CFG
+
+
+value = CFG.some_option
+```
+
+Users who adopt `ConfigSingleton` accept the risks inherent in using a
+global. Those risks are not hidden; `_reset()` is provided
+`_reset()` as an explicit mitigation for the most common consequence:
+test pollution.
+
+Key properties:
+
+- **Lazy**: the underlying `Configuration` is not built until first
+  attribute access, so import-time side-effects and CLI arg injection
+  via `insert_source` are both safe.
+- **Reconstructible**: `_reset()` rebuilds the `Configuration` by
+  calling the factory again, giving tests a clean slate.
+- **Transparent**: all attribute and subscript access is proxied to the
+  underlying `Configuration`; `ConfigSingleton` adds no new config API.
+
+## Options considered
+
+### Optional proxy class (chosen)
+
+- Users opt in explicitly [pro]
+- `Configuration` stays composable [pro]
+- `_reset()` provides test isolation [pro]
+- Still a global; test discipline required [con]
+
+### Make `Configuration` a singleton
+
+- Single concept [pro]
+- Forces singleton semantics on all users [con]
+- Impossible to have two configurations in one process [con]
+
+### No singleton support
+
+- Cleanest design [pro]
+- Users reimplement the pattern themselves, often without `_reset()` [con]
+
+### Dependency injection only
+
+- Testable by construction [pro]
+- Significant boilerplate for simple applications [con]
+- Counter to the target audience [con]
+
+## Rationale
+
+The target audience includes small applications, CLI tools, and
+microservices where the ergonomics of `from yourmodule.conf import CFG`
+outweigh the risks of a global. Providing `ConfigSingleton` as an
+explicit, documented opt-in makes the trade-off visible rather than
+leaving users to implement their own globals without the `_reset()`
+safety valve.
+
+Keeping `Configuration` free of singleton semantics ensures that
+libraries, tests, and multi-configuration scenarios can construct
+independent `Configuration` objects without interference.
+
+## Consequences
+
+- `ConfigSingleton` is opt-in. Projects that prefer dependency injection
+  or explicit `get_config()` calls at each use site can ignore it
+  entirely.
+- Users who adopt `ConfigSingleton` are responsible for test isolation.
+  The recommended pattern is `CFG._reset()` in `tearDown`.
+- `insert_source` works through `ConfigSingleton` via the
+  `_HasConfigSources` protocol, so CLI args can be injected after import
+  and before first access.
+- Two `ConfigSingleton` instances over the same factory are independent
+  objects; there is no process-wide enforcement of uniqueness.

--- a/docs/decisions/0000-foundational/README.md
+++ b/docs/decisions/0000-foundational/README.md
@@ -1,0 +1,15 @@
+# Foundational Decisions
+
+Decisions made before BatConf adopted Architecture Decision Records.
+Reconstructed from source, git history, and project documentation.
+
+| #  | Title                                                                           | Status   |
+| -- | ------------------------------------------------------------------------------- | -------- |
+| 01 | [SourceList first-wins priority](01-source-list-first-wins.md)                  | Accepted |
+| 02 | [Dataclass as config schema](02-dataclass-schema.md)                            | Accepted |
+| 03 | [Zero mandatory external dependencies](03-zero-mandatory-dependencies.md)       | Accepted |
+| 04 | [Module path as default namespace](04-module-path-namespace.md)                 | Accepted |
+| 05 | [Multi-environment config file format](05-multi-environment-file-format.md)     | Accepted |
+| 06 | [String-only config values](06-string-only-values.md)                           | Accepted |
+| 07 | [Source interface: Protocol over ABC](07-source-interface-protocol-over-abc.md) | Accepted |
+| 08 | [ConfigSingleton: optional global configuration](08-config-singleton.md)        | Accepted |

--- a/docs/decisions/0001-file-source-classes/0001-unified-file-source-api.md
+++ b/docs/decisions/0001-file-source-classes/0001-unified-file-source-api.md
@@ -1,0 +1,84 @@
+# ADR 0001 — Unified FileSource API
+
+Date: 2026-05-14
+Status: Proposed
+Branch: feature/file-sources
+Issue: #193
+
+## Context
+
+batconf v0.4.x ships three file-backed configuration sources with inconsistent
+constructor signatures:
+
+| Class        | `file_path` param  | env param                        | format param                       |
+|--------------|--------------------|----------------------------------|------------------------------------|
+| `TomlConfig` | `file_path`        | `config_env: str\|None`          | `file_format`                      |
+| `IniConfig`  | `file_path`        | `config_env: _EnvOpts` (2nd pos) | `file_format` (4th, after env)     |
+| `YamlConfig` | `config_file_name` | `config_env: str\|None`          | `enable_config_environments: bool` |
+
+Callers cannot swap one source for another without updating call sites, and
+no shared type exists for type annotations or `isinstance` checks.
+
+## Decision
+
+Introduce three new classes — `TomlSource`, `IniSource`, `YamlSource` — all
+conforming to a shared `FileSourceP` Protocol:
+
+```python
+class FileSourceP(Protocol):
+    def __init__(
+        self,
+        file_path: str,
+        file_format: Literal[
+            'environments', 'sections', 'flat'] = 'environments',
+        config_env: str | None = None,
+        missing_file_option: Literal['warn', 'ignore', 'error'] = 'warn',
+    ): ...
+
+    def get(self, key: str, path: str | None = None) -> str | None: ...
+
+    def keys(self): ...
+```
+
+The `file_format` argument replaces `enable_config_environments` and makes the
+three modes explicit: `'environments'` (multi-env config with a default
+declared in the file), `'sections'` (top-level sections as namespaces), and
+`'flat'` (all keys at root level).
+
+## Options considered
+
+### Shared ABC base class
+
+- Forces subclasses to implement the interface [pro]
+- Requires inheritance [con]
+- `IniSource` stores a `ConfigParser`, not a plain dict;
+  a shared base class would need empty stubs or overrides for every method [con]
+
+### Protocol (chosen)
+
+- Structural typing; no forced inheritance [pro]
+- `isinstance` check available via `runtime_checkable` [pro]
+- Slightly less familiar than ABCs for contributors new to Protocol [con]
+
+### Leave signatures unchanged
+
+- No migration cost [pro]
+- Callers cannot treat the three sources interchangeably [con]
+- Type annotations impossible without a union type [con]
+
+## Rationale
+
+`IniSource` stores a `ConfigParser` rather than a `dict[str, Any]`, so its
+internal structure differs from `TomlSource` and `YamlSource`. A shared base
+class would either expose implementation details or force empty method stubs.
+A Protocol captures the public contract without constraining the internals.
+
+## Consequences
+
+- `TomlSource`, `IniSource`, `YamlSource` are the canonical file source
+  classes going forward.
+- `from batconf import TomlSource, IniSource, YamlSource` works from v0.4.x.
+- `FileSourceP` is the stable structural type for type annotations.
+- `file_format='environments'` replaces the `enable_config_environments=True`
+  boolean; `'sections'` replaces `enable_config_environments=False`.
+- Old `*Config` classes are deprecated but remain usable; see ADR 0003.

--- a/docs/decisions/0001-file-source-classes/0002-lazy-loading.md
+++ b/docs/decisions/0001-file-source-classes/0002-lazy-loading.md
@@ -1,0 +1,82 @@
+# ADR 0002 — Lazy file loading via `_raw_data`
+
+Date: 2026-05-14
+Status: Proposed
+Branch: feature/file-sources
+Issue: #193
+
+## Context
+
+The v0.4.x `*Config` classes call the file loader in `__init__`, which
+causes two problems:
+
+1. **Testing friction.** Tests that need to inject a known dict must patch the
+   loader function before constructing the object. The patch target differs
+   across the three classes.
+2. **Inconsistent `missing_file_option` semantics.** With eager loading, a
+   `missing_file_option='error'` source raises `FileNotFoundError` at
+   construction time. A `missing_file_option='warn'` source logs at
+   construction time. Users cannot construct the object first and defer the
+   I/O failure to the first `.get()` call.
+
+`IniSource` introduced a partial workaround: a `try/except AttributeError`
+guard in the `_data` property delays the load until first access but is not
+consistent with the other two sources.
+
+## Decision
+
+Move file I/O out of `__init__` into a `cached_property` named `_raw_data`.
+Derive the caller-visible view in a plain `@property` named `_data`:
+
+```
+__init__    stores path, format, options — no I/O
+_raw_data   cached_property — reads file on first access, caches result
+_config_env property with setter — resolved from _raw_data on first _data access
+            when not set by the caller
+_data       property — slices _raw_data by config_env (environments format)
+            or returns _raw_data as-is (sections / flat)
+```
+
+Test injection uses `cached_property`'s storage contract — setting a value
+directly in `__dict__` bypasses computation:
+
+```python
+ts = TomlSource(file_path='irrelevant.toml')
+ts.__dict__['_raw_data'] = {'my_env': {'key': 'value'}}
+ts._config_env = 'my_env'
+assert ts._data == {'key': 'value'}   # no file read
+```
+
+## Options considered
+
+### Eager load in `__init__` (status quo)
+
+- Simple; object is fully populated after construction [pro]
+- Ties construction to I/O [con]
+- Injection-based tests require patching the loader function [con]
+
+### `try/except AttributeError` in property (`IniSource` approach)
+
+- Lazy; no extra import needed [pro]
+- Relies on catching `AttributeError` for normal control flow [con]
+- Not self-documenting [con]
+- Not consistent across sources [con]
+
+### `cached_property` (chosen)
+
+- Standard library; intent is obvious [pro]
+- Test injection via `__dict__` is a documented pattern [pro]
+- Consistent across all three sources [pro]
+- Requires the class not to define `__slots__` [con]
+
+## Consequences
+
+- No file I/O on construction; the first `.get()` or `._data` access triggers
+  the load.
+- `missing_file_option='error'` raises `FileNotFoundError` on first value
+  access, not at construction time.
+- Unit tests inject data via `obj.__dict__['_raw_data'] = {...}` without
+  patching loader functions.
+- `_config_env` is `None` after `__init__` when not provided by the caller;
+  it is populated from the file's `batconf.default_env` key on first `_data`
+  access (environments format only).

--- a/docs/decisions/0001-file-source-classes/0003-import-time-deprecation.md
+++ b/docs/decisions/0001-file-source-classes/0003-import-time-deprecation.md
@@ -1,0 +1,89 @@
+# ADR 0003 — Import-time deprecation via module `__getattr__`
+
+Date: 2026-05-14
+Status: Proposed
+Branch: feature/file-sources
+Issue: #193
+
+## Context
+
+`TomlConfig`, `IniConfig`, and `YamlConfig` must be deprecated without
+breaking code that still uses them. Two questions arise:
+
+1. **When should the warning fire?** At instantiation or at import?
+2. **How do we remove the name from the module without changing the class?**
+
+The v0.4.x initial deprecation implementation used `warnings.warn` inside
+`__init__` (instantiation-time). This approach has two drawbacks: the warning
+fires late (buried inside call stacks, not at the `import` line), and it is
+silenced after the first occurrence per call site by Python's default `once`
+filter — so code that creates many instances only warns once in an
+unpredictable location.
+
+## Decision
+
+### Warning timing — import-time via module `__getattr__`
+
+Python calls a module's `__getattr__` only when the requested name is absent
+from the module's `__dict__`. Assigning a `__getattr__` function and removing
+the old name from globals causes the warning to fire on any attribute access —
+including `from batconf.sources.toml import TomlConfig` — making the
+deprecated name visible immediately in `import` statements that are easy to
+find and fix.
+
+### Class identity — `del` rather than rename
+
+To trigger `__getattr__`, the class name must not be in the module's
+`__dict__`. Two approaches:
+
+| Approach                                   | Effect on `cls.__name__`   | Effect on repr / pickle                                  |
+| ------------------------------------------ | -------------------------- | -------------------------------------------------------- |
+| `class _TomlConfig(TomlSource)`            | `'_TomlConfig'`            | repr and pickle change; existing pickled instances break |
+| `_TomlConfig = TomlConfig; del TomlConfig` | `'TomlConfig'` (unchanged) | No change to repr or pickle                              |
+
+The `del` approach is chosen. The class definition is left untouched; the
+public name is removed from globals after a private reference is saved:
+
+```python
+class TomlConfig(TomlSource): ...   # __name__ = 'TomlConfig'
+
+_TomlConfig = TomlConfig            # save before deletion
+del TomlConfig                      # not in __dict__ → __getattr__ fires
+
+__getattr__ = make_deprecated_getattr(
+    deprecated={'TomlConfig': 'TomlSource'},   # display name in warning
+    module_globals=globals(),
+    module_name=__name__,
+    targets={'TomlConfig': '_TomlConfig'},      # object to return
+)
+```
+
+## Options considered
+
+### `warnings.warn` in `__init__`
+
+- `cls.__name__` unchanged [pro]
+- Warning fires at instantiation, not import [con]
+- Silenced after first hit per call site by Python's default filter [con]
+
+### `class _TomlConfig` + `__getattr__`
+
+- Warning fires at import [pro]
+- `cls.__name__` becomes `'_TomlConfig'` [con]
+- Breaks repr and pickle [con]
+
+### `del TomlConfig` + `__getattr__` (chosen)
+
+- Warning fires at import [pro]
+- `cls.__name__` unchanged [pro]
+- No side effects on the class object [pro]
+
+## Consequences
+
+- `from batconf.sources.toml import TomlConfig` emits `DeprecationWarning`;
+  `toml.TomlConfig` does the same.
+- `TomlConfig.__name__` remains `'TomlConfig'`; repr and pickle are unaffected.
+- `isinstance(tc, TomlConfig)` is not directly possible after import since
+  `TomlConfig` is no longer a module-level name. Users should migrate to
+  `isinstance(tc, TomlSource)`.
+- The deprecated classes are removed in v0.5.0.

--- a/docs/decisions/0001-file-source-classes/0004-compat-module.md
+++ b/docs/decisions/0001-file-source-classes/0004-compat-module.md
@@ -1,0 +1,75 @@
+# ADR 0004 — `_compat.py` shared deprecation utility
+
+Date: 2026-05-14
+Status: Proposed
+Branch: feature/file-sources
+Issue: #193
+
+## Context
+
+All three source modules need the same `__getattr__` pattern described in ADR
+
+0003. Duplicating the implementation across `toml.py`, `ini.py`, and
+      `yaml.py` would mean three copies of the warning format string,
+      stacklevel,
+      and `AttributeError` message.
+
+An additional complication: `IniConfig` and `YamlConfig` have different
+constructor signatures from their `*Source` replacements, so the name returned
+by `__getattr__` is not the same as the display name in the warning message:
+
+- `__getattr__('IniConfig')` → warn `"use 'IniSource' instead"`, but return
+  the legacy `_IniConfig` class (which preserves the old `IniConfig` API)
+- `__getattr__('TomlConfig')` → warn `"use 'TomlSource' instead"`, and the
+  display name and return target are the same (`_TomlConfig`)
+
+## Decision
+
+Add `batconf/sources/_compat.py` with a single public function
+`make_deprecated_getattr`. The function is internal (module prefixed with `_`)
+and not part of the public API.
+
+```python
+def make_deprecated_getattr(
+    deprecated: dict[str, str],  # {old_name: display_new_name}
+    module_globals: dict,
+    module_name: str,
+    targets: dict[str, str] | None = None  # {old_name: globals_key_to_return}
+):
+```
+
+`deprecated` drives the warning message: `"'old_name' is deprecated, use
+'display_new_name' instead."`. `targets`, when provided, overrides which key
+is looked up in `module_globals` to find the object to return. When omitted,
+`display_new_name` is used as the globals key directly.
+
+## Options considered
+
+### Inline `__getattr__` per module
+
+- No shared dependency [pro]
+- Three copies of the same logic [con]
+- Warning format string may diverge over time [con]
+
+### `_compat.py` (chosen)
+
+- Single implementation; tested once [pro]
+- Consistent warning format and stacklevel across all three sources [pro]
+- One more internal module [con]
+
+### Public utility function
+
+- Discoverable [pro]
+- Deprecation machinery is an implementation detail;
+  publishing it sets a maintenance expectation [con]
+
+## Consequences
+
+- `batconf/sources/_compat.py` is an internal module. It must not be imported
+  outside the `batconf.sources` package.
+- `make_deprecated_getattr` is covered by its own unit tests in
+  `batconf/sources/tests/_compat_test.py`.
+- Adding a fourth deprecated source in the future requires only a single
+  `make_deprecated_getattr` call; no logic needs to be duplicated.
+- The `targets` parameter allows the warning message to say `"use 'IniSource'"
+  while still returning the legacy `_IniConfig` wrapper class.

--- a/docs/decisions/0001-file-source-classes/README.md
+++ b/docs/decisions/0001-file-source-classes/README.md
@@ -1,0 +1,16 @@
+# FileSource Class Refactor (4 decisions)
+
+Branch: feature/file-sources
+Issue: #193
+
+Four decisions made during the introduction of `TomlSource`, `IniSource`, and
+`YamlSource` and the deprecation of the legacy `*Config` classes.
+
+| #                                       | Title                                     | Status   |
+| --------------------------------------- | ----------------------------------------- | -------- |
+| [0001](0001-unified-file-source-api.md) | Unified FileSource API + FileSourceP      | Proposed |
+| [0002](0002-lazy-loading.md)            | Lazy file loading via `_raw_data`         | Proposed |
+| [0003](0003-import-time-deprecation.md) | Import-time deprecation via `__getattr__` | Proposed |
+| [0004](0004-compat-module.md)           | `_compat.py` shared deprecation utility   | Proposed |
+
+See [REQUIREMENTS.md](REQUIREMENTS.md) for the acceptance criteria for this PR.

--- a/docs/decisions/0001-file-source-classes/REQUIREMENTS.md
+++ b/docs/decisions/0001-file-source-classes/REQUIREMENTS.md
@@ -1,0 +1,84 @@
+# FileSource Class Refactor — Requirements
+
+> Author: Lundy Bernard
+> Date: 2026-05-14
+> Branch: feature/file-sources
+> Issue: #193
+
+---
+
+## Purpose
+
+Replace the three legacy file-backed configuration classes (`TomlConfig`,
+`IniConfig`, `YamlConfig`) with a unified set of `*Source` classes that share
+a common interface, load files lazily, and deprecate the old names with
+import-time warnings.
+
+---
+
+## Requirements
+
+### R1 — Unified constructor signature
+
+All three file source classes must accept the same four keyword arguments in
+the same order: `file_path`, `file_format`, `config_env`,
+`missing_file_option`. Callers must be able to swap sources without changing
+call sites.
+
+### R2 — Structural protocol
+
+A `FileSourceP` Protocol must be the canonical type for file source objects.
+The Protocol must be checkable with `isinstance` and usable as a type
+annotation. No concrete inheritance from a base class is required.
+
+### R3 — Lazy file loading
+
+No file I/O at construction time. The file must be read on the first access
+of a value, not in `__init__`. A `missing_file_option='error'` source must
+not raise until a `.get()` is called.
+
+### R4 — Consistent `missing_file_option` behaviour
+
+All three sources must support `'warn'`, `'ignore'`, and `'error'` options
+with identical semantics. The behaviour must be exercised by parity integration
+tests that run the same assertions against all three source classes.
+
+### R5 — Deprecation warnings on import
+
+`TomlConfig`, `IniConfig`, and `YamlConfig` must remain importable for one
+release cycle but emit a `DeprecationWarning` when the name is accessed from
+the module. The warning must fire on `from batconf.sources.x import XxxConfig`,
+not on instantiation.
+
+### R6 — Preserved class identity
+
+The deprecated classes must retain their original `__name__` values so that
+existing `repr()` output, error messages, and any pickled instances are
+unaffected.
+
+### R7 — Test parity
+
+Integration tests must verify that `TomlSource`, `IniSource`, and `YamlSource`
+return identical values for the same logical key from equivalent `environments`,
+`sections`, and `flat` config files.
+
+### R8 — No regressions
+
+All existing tests that exercise the old `*Config` classes must continue to
+pass (with warnings suppressed where needed). No public API other than the
+deprecated names may be removed.
+
+---
+
+## Success criteria
+
+- `FileSourceP`, `TomlSource`, `IniSource`, `YamlSource` are exported from
+  `batconf`
+- `from batconf.sources.toml import TomlConfig` emits `DeprecationWarning`;
+  the returned object is a subclass of `TomlSource`
+- `TomlConfig.__name__ == 'TomlConfig'` (and equivalently for Ini/Yaml)
+- `TomlSource(file_path='missing.toml')` raises no exception; first `.get()`
+  on a `missing_file_option='error'` source raises `FileNotFoundError`
+- All parity integration tests pass for all three sources across all three
+  file formats
+- CI green on the final commit

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,21 @@
+# Architecture Decision Records
+
+Significant decisions made during the development of `batconf`. Each ADR
+captures context, options considered, and rationale so future contributors
+understand _why_ the codebase looks the way it does.
+
+## Conventions
+
+- **Standalone decisions** live directly here as `NNNN-title.md`.
+- **Grouped changes** get a numbered subdirectory: `NNNN-topic/`.
+- ADRs are immutable once accepted. To reverse a decision, write a new ADR
+  with `Status: Supersedes NNNN`.
+
+Statuses: `Proposed → Accepted → Deprecated / Superseded by NNNN`
+
+## Index
+
+| #                                              | Title                          | Status   |
+| ---------------------------------------------- | ------------------------------ | -------- |
+| [0000](0000-foundational/)                     | Foundational decisions (8 decisions) | Accepted |
+| [0001](0001-file-source-classes/)              | FileSource class refactor (4 decisions) | Proposed |

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -45,6 +45,9 @@ Features:
 * :class:`~batconf.sources.toml.TomlSource` — standardised TOML file source
   implementing :class:`~batconf.sources.types.FileSourceP`;
   replaces :class:`~batconf.sources.toml.TomlConfig`
+* :class:`~batconf.sources.yaml.YamlSource` — standardised YAML file source
+  implementing :class:`~batconf.sources.types.FileSourceP`;
+  replaces :class:`~batconf.sources.yaml.YamlConfig`
 * New top-level public API — ``Configuration``, ``SourceList``,
   ``NamespaceSource``, ``EnvSource``, ``IniSource``, ``TomlSource``,
   ``YamlSource`` are now importable directly from ``batconf``

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -39,6 +39,12 @@ Features:
   ``Configuration`` or ``ConfigSingleton`` at runtime
 * Subscript access on :class:`~batconf.manager.Configuration`:
   ``cfg['key']`` is equivalent to ``cfg.key``
+* :class:`~batconf.sources.ini.IniSource` — standardised INI file source
+  implementing :class:`~batconf.sources.types.FileSourceP`;
+  replaces :class:`~batconf.sources.ini.IniConfig`
+* :class:`~batconf.sources.toml.TomlSource` — standardised TOML file source
+  implementing :class:`~batconf.sources.types.FileSourceP`;
+  replaces :class:`~batconf.sources.toml.TomlConfig`
 * New top-level public API — ``Configuration``, ``SourceList``,
   ``NamespaceSource``, ``EnvSource``, ``IniSource``, ``TomlSource``,
   ``YamlSource`` are now importable directly from ``batconf``

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -40,8 +40,8 @@ Features:
 * Subscript access on :class:`~batconf.manager.Configuration`:
   ``cfg['key']`` is equivalent to ``cfg.key``
 * New top-level public API — ``Configuration``, ``SourceList``,
-  ``NamespaceSource``, ``EnvSource``, ``IniSource``, ``YamlSource``
-  are now importable directly from ``batconf``
+  ``NamespaceSource``, ``EnvSource``, ``IniSource``, ``TomlSource``,
+  ``YamlSource`` are now importable directly from ``batconf``
 
 .. _v0.3.1:
 

--- a/docs/source/migration.rst
+++ b/docs/source/migration.rst
@@ -26,6 +26,7 @@ The following names are now importable directly from ``batconf``:
 * ``NamespaceSource``, ``Namespace``
 * ``EnvSource``
 * ``IniSource``
+* ``TomlSource``
 * ``YamlSource`` (requires ``batconf[yaml]``)
 
 Old submodule imports still work but the top-level names are now preferred:

--- a/docs/source/migration.rst
+++ b/docs/source/migration.rst
@@ -11,8 +11,8 @@ v0.4.0
 FileConfig Removed
 ========================
 ``batconf.sources.file.FileConfig`` has been removed.
-Replace it with :class:`~batconf.sources.ini.IniConfig` or
-:class:`~batconf.sources.yaml.YamlConfig` as appropriate.
+Replace it with :class:`~batconf.sources.ini.IniSource` or
+:class:`~batconf.sources.yaml.YamlSource` as appropriate.
 
 ========================
 New Public API

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -212,7 +212,7 @@ Access config option values using python's attribute (``.``) notation.
         |    |- port: "5000"
     SourceList=[
         Environment Variables: EnvConfig(),
-        Ini File: IniConfig(file_path=config.ini, config_env=None, missing_file_option=warn, file_format=environments),
+        Ini File: IniSource(file_path=config.ini, config_env=None, missing_file_option=warn, file_format=environments),
     ]
 
     In [3]: cfg.server.host
@@ -268,7 +268,7 @@ configuration options for the ``client`` found in ``yourproject.example.client``
 Ini
 ^^^
 
-:class:`~batconf.sources.ini.IniConfig` supports three file formats,
+:class:`~batconf.sources.ini.IniSource` supports three file formats,
 controlled by the ``file_format`` parameter (default: ``'environments'``):
 
 * ``'environments'`` *(default)* — sections are prefixed with an
@@ -378,8 +378,9 @@ for convenience:
 
 Missing file behaviour
 ^^^^^^^^^^^^^^^^^^^^^^
-Both :class:`~batconf.sources.ini.IniConfig` and
-:class:`~batconf.sources.yaml.YamlConfig` accept a ``missing_file_option``
+All file sources (:class:`~batconf.sources.ini.IniSource`,
+:class:`~batconf.sources.toml.TomlSource`,
+:class:`~batconf.sources.yaml.YamlSource`) accept a ``missing_file_option``
 parameter that controls what happens when the config file is not found:
 
 * ``'warn'`` *(default)* — logs a warning and continues. Safe for

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -302,6 +302,36 @@ controlled by the ``file_format`` parameter (default: ``'environments'``):
     password = lets-add-a-secure-source-for-this
     address = 192.168.1.1
 
+Toml
+^^^^
+
+:class:`~batconf.sources.toml.TomlSource` supports the same three file
+formats as :class:`~batconf.sources.ini.IniSource`, controlled by the
+``file_format`` parameter (default: ``'environments'``):
+
+* ``'environments'`` *(default)* — top-level tables are prefixed with an
+  environment name. A ``[batconf]`` table declares the default environment
+  via ``default_env``.
+* ``'sections'`` — tables use the dotted config path directly
+  (e.g. ``[yourproject.example.client]``), with no environment prefix.
+* ``'flat'`` — a single flat key/value file with no tables.
+
+.. code-block:: toml
+    :caption: config.toml (environments format — default)
+
+    [batconf]
+    default_env = 'dev'
+
+    [dev.yourproject.example.client]
+    username = 'devusr'
+    password = 'changeme'
+    address = '0.0.0.0'
+
+    [prod.yourproject.example.client]
+    username = 'produser'
+    password = 'lets-add-a-secure-source-for-this'
+    address = '192.168.1.1'
+
 Yaml
 ^^^^
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -335,14 +335,15 @@ formats as :class:`~batconf.sources.ini.IniSource`, controlled by the
 Yaml
 ^^^^
 
-:class:`~batconf.sources.yaml.YamlConfig` uses an environment-based
-structure by default. The top-level ``default`` key sets the active
-environment when ``config_env`` is not specified at runtime.
+:class:`~batconf.sources.yaml.YamlSource` supports the same three file
+formats as :class:`~batconf.sources.ini.IniSource`, controlled by the
+``file_format`` parameter (default: ``'environments'``).
 
 .. code-block:: yaml
-    :caption: config.yaml
+    :caption: config.yaml (environments format — default)
 
-    default: dev
+    batconf:
+      default_env: dev
 
     dev:
       yourproject:

--- a/notebooks/Example.ipynb
+++ b/notebooks/Example.ipynb
@@ -83,18 +83,7 @@
    "id": "2e7ab0a62be98ef6",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from batconf.sources.toml import TomlConfig\n",
-    "\n",
-    "\n",
-    "cfg = get_config(\n",
-    "    config_file=TomlConfig('config.sections.toml', file_format='sections')\n",
-    ")\n",
-    "print(cfg)\n",
-    "\n",
-    "print(cfg.doc)\n",
-    "print(cfg.client.doc)"
-   ]
+   "source": "from batconf.sources.toml import TomlSource\n\n\ncfg = get_config(\n    config_file=TomlSource('config.sections.toml', file_format='sections')\n)\nprint(cfg)\n\nprint(cfg.doc)\nprint(cfg.client.doc)"
   },
   {
    "cell_type": "markdown",
@@ -112,14 +101,7 @@
    "id": "317137c90f1c7af6",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from batconf.sources.toml import TomlConfig\n",
-    "\n",
-    "\n",
-    "cfg = get_config(config_file=TomlConfig('config.flat.toml', file_format='flat'))\n",
-    "# TODO: This is currently failing but should work\n",
-    "print(cfg.doc)"
-   ]
+   "source": "from batconf.sources.toml import TomlSource\n\n\ncfg = get_config(config_file=TomlSource('config.flat.toml', file_format='flat'))\n# TODO: This is currently failing but should work\nprint(cfg.doc)"
   },
   {
    "cell_type": "markdown",

--- a/notebooks/config.py
+++ b/notebooks/config.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from batconf.manager import Configuration
 from batconf.types import ConfigP
 from batconf.source import SourceList, SourceInterface
+from batconf.types import SourceInterfaceP
 from batconf.sources.ini import IniConfig
 
 
@@ -54,7 +55,7 @@ def get_config(
     :param cli_args: :class:`Namespace` provided by python's builtin argparse
     :param config_file: Optional config file source injection.  Initialize
     any `batconf.sources.` *Config class
-    [`IniConfig`, `TomlConfig`, `YamlConfig`],
+    [`IniConfig`, `TomlSource`, `YamlConfig`],
     and use it as the config file source
     :param config_file_name:
     :param config_env: Environment id string, ex: 'dev', 'staging', 'yourname'
@@ -65,7 +66,7 @@ def get_config(
     """
 
     # Build a prioritized config source list
-    config_sources: Sequence[SourceInterface | None] = [
+    config_sources: Sequence[SourceInterfaceP | None] = [
         (
             config_file
             if config_file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ lint = [
 typecheck = [
     "mypy",
     "types-PyYAML",
+    "types-toml",
 ]
 
 # convenience group for local development:

--- a/tests/example/config.yaml
+++ b/tests/example/config.yaml
@@ -1,4 +1,5 @@
-default: "test"
+batconf:
+  default_env: test
 
 test:
   project:

--- a/tests/example/example_test.py
+++ b/tests/example/example_test.py
@@ -293,7 +293,7 @@ class LibTests(TestCase):
             '    |    |    |- key2: "DEFAULT VALUE"\n'
             'SourceList=[\n'
             f'    Environment Variables: EnvConfig(),\n'
-            f'    Ini File: IniConfig(file_path={CONFIG_FILE_NAME}, '
+            f'    Ini File: IniSource(file_path={CONFIG_FILE_NAME}, '
             'config_env=test, missing_file_option=warn, '
             'file_format=environments),\n'
             ']',

--- a/tests/example/example_test.py
+++ b/tests/example/example_test.py
@@ -315,7 +315,7 @@ def set_environ(key: str, value: str):
 class GetYamlConfigFunctionTests(TestCase):
     def setUp(t):
         # Inject a YamlConfig file source, to overwrite the default .ini
-        t.yaml_config = YamlSource(config_file_name=yaml_config_file_name)
+        t.yaml_config = YamlSource(file_path=yaml_config_file_name)
 
     def test_get_config(t):
         """get_config() returns a Project-level Configuration object.

--- a/tests/integration/data/envs.config.yaml
+++ b/tests/integration/data/envs.config.yaml
@@ -1,0 +1,15 @@
+batconf:
+  default_env: test
+
+test:
+  doc: our testing environment
+  project:
+    submodule:
+      sub:
+        key1: 'envs.config.yaml: test.project.submodule.sub.key1'
+        integer: '0'
+
+production:
+  doc: Options for the production environment
+  project:
+    doc: Python module specific options

--- a/tests/integration/data/flat.config.yaml
+++ b/tests/integration/data/flat.config.yaml
@@ -1,0 +1,3 @@
+value0: value 0
+int: '0'
+root: is a valid key

--- a/tests/integration/data/sections.config.toml
+++ b/tests/integration/data/sections.config.toml
@@ -9,3 +9,9 @@ section.name = 'section 7'
 [section.9]
 section.name = 'section 9'
 key1 = 'val1'
+
+[sec0.sub0]
+value0 = 'sections.config.toml :: sec0.sub0 :: value0'
+
+[sec1]
+value0 = 'sections.config.toml :: sec1 :: value0'

--- a/tests/integration/data/sections.config.yaml
+++ b/tests/integration/data/sections.config.yaml
@@ -1,0 +1,5 @@
+sec0:
+  sub0:
+    value0: 'sections.config.yaml :: sec0.sub0 :: value0'
+sec1:
+  value0: 'sections.config.yaml :: sec1 :: value0'

--- a/tests/integration/file_source_parity_test.py
+++ b/tests/integration/file_source_parity_test.py
@@ -1,0 +1,167 @@
+from unittest import TestCase
+from os import path
+
+from batconf import IniSource, TomlSource, YamlSource
+from batconf.types import FILE_FORMATS
+
+
+_TOML_INSTALLED = True
+try:
+    import tomllib  # type: ignore[import-not-found]  # noqa: F401
+except ImportError:
+    try:
+        import toml  # noqa: F401
+    except ImportError:
+        _TOML_INSTALLED = False
+
+_PYYAML_INSTALLED = True
+try:
+    import yaml  # noqa: F401
+except ImportError:
+    _PYYAML_INSTALLED = False
+
+
+_DATA_DIR = path.join(path.dirname(path.realpath(__file__)), 'data')
+
+_SOURCE_EXT = {
+    IniSource: 'ini',
+    TomlSource: 'toml',
+    YamlSource: 'yaml',
+}
+
+_FORMAT_PREFIX = {
+    'environments': 'envs',
+    'sections': 'sections',
+    'flat': 'flat',
+}
+
+_ALL_SOURCES = [
+    s
+    for s in [
+        IniSource,
+        TomlSource if _TOML_INSTALLED else None,
+        YamlSource if _PYYAML_INSTALLED else None,
+    ]
+    if s is not None
+]
+
+
+def _file_path(source_class, file_format):
+    prefix = _FORMAT_PREFIX[file_format]
+    ext = _SOURCE_EXT[source_class]
+    return path.join(_DATA_DIR, f'{prefix}.config.{ext}')
+
+
+class FileSourceSignatureParityTests(TestCase):
+    """All file sources accept the same FileSourceP constructor arguments."""
+
+    def test_all_sources_accept_FileSourceP_args(t):
+        for file_format in FILE_FORMATS:
+            for source_class in _ALL_SOURCES:
+                with t.subTest(
+                    source=source_class.__name__,
+                    file_format=file_format,
+                ):
+                    src = source_class(
+                        file_path='nonexistent.file',
+                        file_format=file_format,
+                        missing_file_option='ignore',
+                    )
+                    t.assertIsNotNone(src)
+
+    def test_missing_key_returns_None_for_all_sources(t):
+        for file_format in FILE_FORMATS:
+            for source_class in _ALL_SOURCES:
+                with t.subTest(
+                    source=source_class.__name__, file_format=file_format
+                ):
+                    src = source_class(
+                        file_path='nonexistent.file',
+                        file_format=file_format,
+                        missing_file_option='ignore',
+                    )
+                    t.assertIsNone(src.get('missing.key'))
+                    t.assertIsNone(src.get('key', path='missing.path'))
+
+
+class FileSourceValueParityTests(TestCase):
+    """All file sources return equivalent values for the same logical key."""
+
+    def setUp(t):
+        t.env_sources = [
+            t._load(cls, 'environments')
+            for cls in _ALL_SOURCES
+            if cls is not None
+        ]
+
+    def _load(t, source_class, file_format):
+        return source_class(
+            file_path=_file_path(source_class, file_format),
+            file_format=file_format,
+        )
+
+    def test_environments_format_parity(t):
+        sources = [
+            t._load(cls, 'environments')
+            for cls in _ALL_SOURCES
+            if cls is not None
+        ]
+        for src in sources:
+            with t.subTest(source=type(src).__name__):
+                t.assertEqual(src.get('doc'), 'our testing environment')
+                t.assertIsNotNone(src.get('project.submodule.sub.key1'))
+                t.assertIsNone(src.get('missing_key'))
+                t.assertIsNone(src.get('project.submodule'))
+
+    def test_sections_format_parity(t):
+        sources = [
+            t._load(cls, 'sections')  # nofmt
+            for cls in _ALL_SOURCES
+            if cls is not None
+        ]
+        for src in sources:
+            with t.subTest(source=type(src).__name__):
+                t.assertIsNotNone(src.get('sec0.sub0.value0'))
+                t.assertIsNone(src.get('missing_key'))
+                t.assertIsNone(src.get('sec0'))
+
+    def test_flat_format_parity(t):
+        sources = [
+            t._load(cls, 'flat')  # nofmt
+            for cls in _ALL_SOURCES
+            if cls is not None
+        ]
+        for src in sources:
+            with t.subTest(source=type(src).__name__):
+                t.assertEqual(src.get('int'), '0')
+                t.assertEqual(src.get('root'), 'is a valid key')
+                t.assertIsNone(src.get('missing_key'))
+
+    def test_path_past_terminal_string_returns_None(t):
+        """Traversing past a leaf string value returns None, not an error.
+
+        Dict-traversal sources (TOML, YAML) also emit a WARNING.
+        IniSource handles this natively via ConfigParser fallback — no warning.
+        """
+        cases = [
+            ('environments', t.env_sources),
+            ('sections', [t._load(cls, 'sections') for cls in _ALL_SOURCES]),
+        ]
+        keys = {
+            'environments': ('nonexistent', 'project.submodule.sub.key1'),
+            'sections': ('nonexistent', 'sec0.sub0.value0'),
+        }
+        for fmt, sources in cases:
+            key, path = keys[fmt]
+            for src in sources:
+                with t.subTest(fmt=fmt, source=type(src).__name__):
+                    if isinstance(src, IniSource):
+                        t.assertIsNone(src.get(key, path=path))
+                    else:
+                        with t.assertLogs(type(src).__module__, level='WARNING') as cm:
+                            result = src.get(key, path=path)
+                        t.assertIsNone(result)
+                        t.assertEqual(
+                            cm.records[0].getMessage(),
+                            f'Config path {path}.{key} does not exist',
+                        )

--- a/tests/integration/ini_test.py
+++ b/tests/integration/ini_test.py
@@ -1,16 +1,35 @@
+import warnings
+
 from unittest import TestCase
 from unittest.mock import patch, Mock
 
 from os import path
 
-from batconf.sources.ini import IniConfig, IniSource
+import warnings as _warnings_module
+with _warnings_module.catch_warnings():
+    _warnings_module.simplefilter('ignore', DeprecationWarning)
+    from batconf.sources.ini import IniConfig
+from batconf.sources.ini import IniSource
 from batconf.types import FILE_FORMATS
 
 
 class IniConfigIntegrationTests(TestCase):
     def setUp(t):
-        # Get the absolute path to the test config.yaml file
         t.this_dir = path.dirname(path.realpath(__file__))
+
+        w = warnings.catch_warnings()
+        w.__enter__()
+        warnings.simplefilter('ignore', DeprecationWarning)
+        t.addCleanup(w.__exit__, None, None, None)
+
+    def test_is_deprecated(t):
+        import batconf.sources.ini as ini_module
+        with t.assertWarns(DeprecationWarning) as cm:
+            ini_module.__getattr__('IniConfig')
+        t.assertEqual(
+            "'IniConfig' is deprecated, use 'IniSource' instead.",
+            str(cm.warning),
+        )
 
     def test_ini_file_source_defaults(t):
         """Test the Default behavior of the IniConfig configuration source"""
@@ -35,7 +54,7 @@ class IniConfigIntegrationTests(TestCase):
         t.config_file_path = path.join(t.this_dir, 'data/sections.config.ini')
         ic = IniConfig(file_path=t.config_file_path, file_format='sections')
 
-        # Sections allow values to be nested* by their path
+        # Sections allow values to be nested by their path
         t.assertEqual(
             ic.get('sec0.sub0.value0'),
             'sections.config.ini :: sec0.sub0 :: value0',
@@ -66,6 +85,11 @@ class IniConfigMissingFileTests(TestCase):
     def setUp(t):
         t.filename = 'sir.not.appearing.in.this.film'
 
+        w = warnings.catch_warnings()
+        w.__enter__()
+        warnings.simplefilter('ignore', DeprecationWarning)
+        t.addCleanup(w.__exit__, None, None, None)
+
     def test_warning_default(t):
         # The same behavior applies to all file formats
         for file_format in FILE_FORMATS:
@@ -76,11 +100,11 @@ class IniConfigMissingFileTests(TestCase):
                         file_format=file_format,
                         # missing_file_option='warning', is the default value
                     )
+                    # and all calls to .get will return None
+                    t.assertIsNone(ic.get('root'))
                     log.warning.assert_called_with(
                         f'Config file not found: {t.filename}'
                     )
-                # and all calls to .get will return None
-                t.assertIsNone(ic.get('root'))
                 t.assertIsNone(ic.get('project.submodule.sub.key1'))
                 t.assertIsNone(ic.get('any.random.key'))
 
@@ -91,11 +115,12 @@ class IniConfigMissingFileTests(TestCase):
         for file_format in FILE_FORMATS:
             with t.subTest(file_format=file_format):
                 with t.assertRaises(FileNotFoundError):
-                    _ = IniConfig(
+                    ic = IniConfig(
                         file_path=t.filename,
                         missing_file_option='error',
                         file_format=file_format,
                     )
+                    ic.get('any_key')
 
     def test_missing_file_ignore(t):
         """when missing_file_option='ignore'

--- a/tests/integration/ini_test.py
+++ b/tests/integration/ini_test.py
@@ -1,9 +1,10 @@
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 from os import path
 
-from batconf.sources.ini import IniConfig
+from batconf.sources.ini import IniConfig, IniSource
+from batconf.types import FILE_FORMATS
 
 
 class IniConfigIntegrationTests(TestCase):
@@ -67,7 +68,7 @@ class IniConfigMissingFileTests(TestCase):
 
     def test_warning_default(t):
         # The same behavior applies to all file formats
-        for file_format in ['environments', 'sections', 'flat']:
+        for file_format in FILE_FORMATS:
             with t.subTest(file_format=file_format):
                 with patch('batconf.sources.file.log') as log:
                     ic = IniConfig(
@@ -87,7 +88,7 @@ class IniConfigMissingFileTests(TestCase):
         """when missing_file_option='error'
         attempting to load a missing file will raise a FileNotFoundError
         """
-        for file_format in ['environments', 'sections', 'flat']:
+        for file_format in FILE_FORMATS:
             with t.subTest(file_format=file_format):
                 with t.assertRaises(FileNotFoundError):
                     _ = IniConfig(
@@ -100,8 +101,7 @@ class IniConfigMissingFileTests(TestCase):
         """when missing_file_option='ignore'
         attempting to load a missing file will not raise an error
         """
-        file_formats = ['environments', 'sections', 'flat']
-        for file_format in file_formats:
+        for file_format in FILE_FORMATS:
             with t.subTest(file_format=file_format):
                 ic = IniConfig(
                     file_path=t.filename,
@@ -113,3 +113,100 @@ class IniConfigMissingFileTests(TestCase):
                 t.assertIsNone(ic.get('doc'))
                 t.assertIsNone(ic.get('project.submodule.sub.key1'))
                 t.assertIsNone(ic.get('any.random.key'))
+
+
+class IniSourceIntegrationTests(TestCase):
+    def setUp(t):
+        t.this_dir = path.dirname(path.realpath(__file__))
+
+    def test_ini_file_source_defaults(t):
+        """Test the Default behavior of the IniSource configuration source"""
+        t.config_file_path = path.join(t.this_dir, 'data/envs.config.ini')
+        ins = IniSource(file_path=t.config_file_path)
+
+        # selects default environment from the config file
+        # get a value from the root of the default environment
+        t.assertEqual('our testing environment', ins.get('doc'))
+        # get a deeply nested value, from the default environment
+        t.assertEqual(
+            'envs.config.ini: test.project.submodule.sub.key1',
+            ins.get('project.submodule.sub.key1'),
+        )
+        # getting a section returns None
+        t.assertIsNone(ins.get('test.project.submodule'))
+
+    def test_section_file(t):
+        """Section files have no environment parameter,
+        all sections of the file are available.
+        """
+        t.config_file_path = path.join(t.this_dir, 'data/sections.config.ini')
+        ins = IniSource(file_path=t.config_file_path, file_format='sections')
+
+        # Sections allow values to be nested by their path
+        t.assertEqual(
+            ins.get('sec0.sub0.value0'),
+            'sections.config.ini :: sec0.sub0 :: value0',
+        )
+        # Section files require a section be specified for every get request
+        t.assertIsNone(ins.get('a_root_value'))
+        # getting a section returns None
+        t.assertIsNone(ins.get('sec1'))
+
+    def test_flat_file(t):
+        t.config_file_path = path.join(t.this_dir, 'data/flat.config.ini')
+        ins = IniSource(file_path=t.config_file_path, file_format='flat')
+
+        # all keys are root values
+        t.assertEqual('value 0', ins.get('value0'))
+        t.assertEqual('0', ins.get('int'))
+        # undefined values return None
+        t.assertIsNone(ins.get('undefined-key'))
+        # keys may have .'s in them, to simulate nested paths
+        t.assertEqual('still a root value', ins.get('not.really.nested'))
+        # root is a valid key, in spite of the default section name
+        t.assertEqual('is a valid key', ins.get('root'))
+
+
+class IniSourceMissingFileTests(TestCase):
+    """Test configurable behavior when the specified config file is missing."""
+
+    def setUp(t):
+        t.filename = 'sir.not.appearing.in.this.film'
+
+    @patch('batconf.sources.file.log', autospec=True)
+    def test_warning_default(t, log: Mock):
+        for file_format in FILE_FORMATS:
+            with t.subTest(file_format=file_format):
+                ins = IniSource(
+                    file_path=t.filename,
+                    file_format=file_format,
+                )
+                t.assertIsNone(ins.get('root'))
+                log.warning.assert_called_with(
+                    f'Config file not found: {t.filename}'
+                )
+                t.assertIsNone(ins.get('project.submodule.sub.key1'))
+                t.assertIsNone(ins.get('any.random.key'))
+
+    def test_missing_file_error(t):
+        for file_format in FILE_FORMATS:
+            with t.subTest(file_format=file_format):
+                with t.assertRaises(FileNotFoundError):
+                    ins = IniSource(
+                        file_path=t.filename,
+                        missing_file_option='error',
+                        file_format=file_format,
+                    )
+                    ins.get('any_key')
+
+    def test_missing_file_ignore(t):
+        for file_format in FILE_FORMATS:
+            with t.subTest(file_format=file_format):
+                ins = IniSource(
+                    file_path=t.filename,
+                    missing_file_option='ignore',
+                    file_format=file_format,
+                )
+                t.assertIsNone(ins.get('doc'))
+                t.assertIsNone(ins.get('project.submodule.sub.key1'))
+                t.assertIsNone(ins.get('any.random.key'))

--- a/tests/integration/toml_test.py
+++ b/tests/integration/toml_test.py
@@ -85,6 +85,10 @@ class TomlSourceIntegrationTests(TestCase):
         t.assertIsNone(ts.get('section 001'))
         t.assertIsNone(ts.get('section.7'))
 
+        # Parity keys shared with ini and yaml section files
+        t.assertIsNotNone(ts.get('sec0.sub0.value0'))
+        t.assertIsNone(ts.get('sec0'))
+
     def test_flat_file(t):
         t.config_file_path = path.join(t.this_dir, 'data/flat.config.toml')
         ts = TomlSource(file_path=t.config_file_path, file_format='flat')

--- a/tests/integration/toml_test.py
+++ b/tests/integration/toml_test.py
@@ -1,9 +1,11 @@
+import warnings
 from unittest import TestCase, skipIf
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 from os import path
 
-from batconf.sources.toml import TomlConfig
+from batconf.sources.toml import TomlSource
+from batconf.types import FILE_FORMATS
 from batconf.sources.tests.toml_test import (
     EXAMPLE_ENVIRONMENTS_TOML,
     LOADED_ENV_DICT,
@@ -13,12 +15,13 @@ from batconf.sources.tests.toml_test import (
     LOAD_FLAT_DICT,
 )
 
+
 _TOML_INSTALLED = True
 try:
-    from tomllib import loads  # type: ignore  # noqa
+    from tomllib import loads  # type: ignore[import-not-found]
 except ImportError:
     try:
-        from toml import loads  # type: ignore  # noqa
+        from toml import loads  # type: ignore[assignment]
     except ImportError:
         _TOML_INSTALLED = False
 
@@ -44,111 +47,131 @@ class TomlUnittestStaticValuesTests(TestCase):
 
 
 @skipIf(not _TOML_INSTALLED, 'toml is not available, skipping')
-class TomlConfigIntegrationTests(TestCase):
+class TomlSourceIntegrationTests(TestCase):
     def setUp(t):
         # Get the absolute path to the test config.yaml file
         t.this_dir = path.dirname(path.realpath(__file__))
 
     def test_toml_file_source_defaults(t):
-        """Test the Default behavior of the TomlConfig configuration source"""
+        """Test the Default behavior of the TomlSource configuration source"""
         t.config_file_path = path.join(t.this_dir, 'data/envs.config.toml')
-        ic = TomlConfig(file_path=t.config_file_path)
+        ts = TomlSource(file_path=t.config_file_path)
 
         # selects default environment from the config file
         # get a value from the root of the default environment
-        t.assertEqual('our testing environment', ic.get('doc'))
+        t.assertEqual('our testing environment', ts.get('doc'))
         # get a deeply nested value, from the default environment
         t.assertEqual(
             'envs.config.toml: test.project.submodule.sub.key1',
-            ic.get('project.submodule.sub.key1'),
+            ts.get('project.submodule.sub.key1'),
         )
         # getting a section returns None
-        t.assertIsNone(ic.get('test.project.submodule'))
+        t.assertIsNone(ts.get('test.project.submodule'))
 
     def test_section_file(t):
         """Section files have no environment parameter,
         all sections of the file are available.
         """
         t.config_file_path = path.join(t.this_dir, 'data/sections.config.toml')
-        ic = TomlConfig(file_path=t.config_file_path, file_format='sections')
+        ts = TomlSource(file_path=t.config_file_path, file_format='sections')
 
         # Sections allow values to be "nested" by their path
-        t.assertEqual(ic.get('section 001.section.name'), 'section 1')
-        t.assertEqual(ic.get('section.9.key1'), 'val1')
+        t.assertEqual(ts.get('section 001.section.name'), 'section 1')
+        t.assertEqual(ts.get('section.9.key1'), 'val1')
 
         # Section files do support implicit root values without a section
-        t.assertEqual(ic.get('a_root_value'), 'is a valid key')
+        t.assertEqual(ts.get('a_root_value'), 'is a valid key')
         # getting a section returns None
-        t.assertIsNone(ic.get('section 001'))
-        t.assertIsNone(ic.get('section.7'))
+        t.assertIsNone(ts.get('section 001'))
+        t.assertIsNone(ts.get('section.7'))
 
     def test_flat_file(t):
         t.config_file_path = path.join(t.this_dir, 'data/flat.config.toml')
-        ic = TomlConfig(file_path=t.config_file_path, file_format='flat')
+        ts = TomlSource(file_path=t.config_file_path, file_format='flat')
 
         # all keys are root values
-        t.assertEqual(ic.get('key0'), 'value0')
-        t.assertEqual(ic.get('int'), '0')
+        t.assertEqual(ts.get('key0'), 'value0')
+        t.assertEqual(ts.get('int'), '0')
         # undefined values return None
-        t.assertIsNone(ic.get('undefined-key'))
+        t.assertIsNone(ts.get('undefined-key'))
         # keys may have .'s in them, to simulate nested paths
-        t.assertEqual(ic.get('not.really.nested'), 'still a root value')
+        t.assertEqual(ts.get('not.really.nested'), 'still a root value')
         # root is a valid key, in spite of the default section name
-        t.assertEqual(ic.get('root'), 'is a valid key')
+        t.assertEqual(ts.get('root'), 'is a valid key')
 
 
 @skipIf(not _TOML_INSTALLED, 'toml is not available, skipping')
-class TomlConfigMissingFileTests(TestCase):
+class TomlSourceMissingFileTests(TestCase):
     """Test configurable behavior when the specified config file is missing."""
 
     def setUp(t):
         t.filename = 'sir.not.appearing.in.this.film'
 
-    def test_warning_default(t):
+    @patch('batconf.sources.file.log', autospec=True)
+    def test_warning_default(t, log: Mock):
         # The same behavior applies to all file formats
-        for file_format in ['environments', 'sections', 'flat']:
+        for file_format in FILE_FORMATS:
             with t.subTest(file_format=file_format):
-                with patch('batconf.sources.file.log') as log:
-                    ic = TomlConfig(
-                        file_path=t.filename,
-                        file_format=file_format,
-                        # missing_file_option='warning', is the default value
-                    )
-                    log.warning.assert_called_with(
-                        f'Config file not found: {t.filename}'
-                    )
-                # and all calls to .get will return None
-                t.assertIsNone(ic.get('root'))
-                t.assertIsNone(ic.get('project.submodule.sub.key1'))
-                t.assertIsNone(ic.get('any.random.key'))
+                ts = TomlSource(
+                    file_path=t.filename,
+                    file_format=file_format,
+                    # missing_file_option='warning', is the default value
+                )
+                # lazy: warning emitted on first data access, not construction
+                t.assertIsNone(ts.get('root'))
+                log.warning.assert_called_with(
+                    f'Config file not found: {t.filename}'
+                )
+            # and all calls to .get will return None
+            t.assertIsNone(ts.get('project.submodule.sub.key1'))
+            t.assertIsNone(ts.get('any.random.key'))
 
     def test_missing_file_error(t):
         """when missing_file_option='error'
         attempting to load a missing file will raise a FileNotFoundError
         """
-        for file_format in ['environments', 'sections', 'flat']:
+        for file_format in FILE_FORMATS:
             with t.subTest(file_format=file_format):
+                ts = TomlSource(
+                    file_path=t.filename,
+                    missing_file_option='error',
+                    file_format=file_format,
+                )
+                # lazy: error raised on first data access, not construction
                 with t.assertRaises(FileNotFoundError):
-                    _ = TomlConfig(
-                        file_path=t.filename,
-                        missing_file_option='error',
-                        file_format=file_format,
-                    )
+                    ts.get('root')
 
     def test_missing_file_ignore(t):
         """when missing_file_option='ignore'
         attempting to load a missing file will not raise an error
         """
-        file_formats = ['environments', 'sections', 'flat']
-        for file_format in file_formats:
+        for file_format in FILE_FORMATS:
             with t.subTest(file_format=file_format):
-                ic = TomlConfig(
+                ts = TomlSource(
                     file_path=t.filename,
                     missing_file_option='ignore',
                     file_format=file_format,
                 )
 
                 # and all calls to .get will return None
-                t.assertIsNone(ic.get('doc'))
-                t.assertIsNone(ic.get('project.submodule.sub.key1'))
-                t.assertIsNone(ic.get('any.random.key'))
+                t.assertIsNone(ts.get('doc'))
+                t.assertIsNone(ts.get('project.submodule.sub.key1'))
+                t.assertIsNone(ts.get('any.random.key'))
+
+
+class DeprecationTests(TestCase):
+    def test_TomlConfig_fires_warning_on_access(t):
+        import batconf.sources.toml as toml_module
+        with t.assertWarns(DeprecationWarning) as cm:
+            TomlConfig = toml_module.__getattr__('TomlConfig')
+        t.assertEqual(
+            "'TomlConfig' is deprecated, use 'TomlSource' instead.",
+            str(cm.warning),
+        )
+
+    def test_TomlConfig_is_TomlSource_subclass(t):
+        import batconf.sources.toml as toml_module
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            TomlConfig = toml_module.__getattr__('TomlConfig')
+        t.assertTrue(issubclass(TomlConfig, TomlSource))

--- a/tests/integration/yaml_opt_test.py
+++ b/tests/integration/yaml_opt_test.py
@@ -1,3 +1,4 @@
+import warnings
 from unittest import TestCase, skipIf
 from unittest.mock import patch
 
@@ -40,8 +41,11 @@ class SourcesYamlUnittestStaticValuesTests(TestCase):
 @skipIf(not _PYYAML_INSTALLED, 'optional pyyaml module not installed')
 class YamlFileIntegrationTests(TestCase):
     def setUp(t):
-        # Get the absolute path to the test config.yaml file
         t.this_dir = path.dirname(path.realpath(__file__))
+        w = warnings.catch_warnings()
+        w.__enter__()
+        warnings.simplefilter('ignore', DeprecationWarning)
+        t.addCleanup(w.__exit__, None, None, None)
 
     def test_yaml_file_source_defaults(t):
         # Get the OS-agnostic absolute path to the test config.yaml file
@@ -60,6 +64,10 @@ class YamlConfigMissingFileTests(TestCase):
 
     def setUp(t):
         t.filename = 'sir.not.appearing.in.this.film'
+        w = warnings.catch_warnings()
+        w.__enter__()
+        warnings.simplefilter('ignore', DeprecationWarning)
+        t.addCleanup(w.__exit__, None, None, None)
 
     def test_warning_default(t):
         # The same behavior applies to all file formats

--- a/tests/integration/yaml_test.py
+++ b/tests/integration/yaml_test.py
@@ -1,0 +1,102 @@
+from unittest import TestCase, skipIf
+from unittest.mock import patch, Mock
+
+from os import path
+
+from batconf.sources.yaml import YamlSource
+from batconf.types import FILE_FORMATS
+
+
+_PYYAML_INSTALLED = True
+try:
+    import yaml  # noqa: F401
+except ImportError:
+    _PYYAML_INSTALLED = False
+
+
+@skipIf(not _PYYAML_INSTALLED, 'optional pyyaml module not installed')
+class YamlSourceIntegrationTests(TestCase):
+    def setUp(t):
+        t.this_dir = path.dirname(path.realpath(__file__))
+
+    def test_yaml_file_source_defaults(t):
+        t.config_file_path = path.join(t.this_dir, 'data/envs.config.yaml')
+        ys = YamlSource(file_path=t.config_file_path)
+
+        t.assertEqual('our testing environment', ys.get('doc'))
+        t.assertEqual(
+            'envs.config.yaml: test.project.submodule.sub.key1',
+            ys.get('project.submodule.sub.key1'),
+        )
+        t.assertIsNone(ys.get('project.submodule'))
+
+    def test_section_file(t):
+        t.config_file_path = path.join(t.this_dir, 'data/sections.config.yaml')
+        ys = YamlSource(file_path=t.config_file_path, file_format='sections')
+
+        t.assertEqual(
+            'sections.config.yaml :: sec0.sub0 :: value0',
+            ys.get('sec0.sub0.value0'),
+        )
+        t.assertIsNone(ys.get('sec0'))
+        t.assertIsNone(ys.get('sec0.sub0'))
+
+    def test_flat_file(t):
+        t.config_file_path = path.join(t.this_dir, 'data/flat.config.yaml')
+        ys = YamlSource(file_path=t.config_file_path, file_format='flat')
+
+        t.assertEqual('value 0', ys.get('value0'))
+        t.assertEqual('0', ys.get('int'))
+        t.assertIsNone(ys.get('undefined-key'))
+        t.assertEqual('is a valid key', ys.get('root'))
+
+    def test_config_env_argument(t):
+        t.config_file_path = path.join(t.this_dir, 'data/envs.config.yaml')
+        ys = YamlSource(file_path=t.config_file_path, config_env='production')
+        t.assertEqual('Options for the production environment', ys.get('doc'))
+
+
+@skipIf(not _PYYAML_INSTALLED, 'optional pyyaml module not installed')
+class YamlSourceMissingFileTests(TestCase):
+    def setUp(t):
+        t.filename = 'sir.not.appearing.in.this.film'
+
+    @patch('batconf.sources.file.log', autospec=True)
+    def test_warning_default(t, log: Mock):
+        for file_format in FILE_FORMATS:
+            with t.subTest(file_format=file_format):
+                ys = YamlSource(
+                    file_path=t.filename,
+                    file_format=file_format,
+                )
+                # lazy: warning emitted on first data access, not construction
+                t.assertIsNone(ys.get('root'))
+                log.warning.assert_called_with(
+                    f'Config file not found: {t.filename}'
+                )
+            t.assertIsNone(ys.get('project.submodule.sub.key1'))
+            t.assertIsNone(ys.get('any.random.key'))
+
+    def test_missing_file_error(t):
+        for file_format in FILE_FORMATS:
+            with t.subTest(file_format=file_format):
+                ys = YamlSource(
+                    file_path=t.filename,
+                    missing_file_option='error',
+                    file_format=file_format,
+                )
+                # lazy: error raised on first data access, not construction
+                with t.assertRaises(FileNotFoundError):
+                    ys.get('root')
+
+    def test_missing_file_ignore(t):
+        for file_format in FILE_FORMATS:
+            with t.subTest(file_format=file_format):
+                ys = YamlSource(
+                    file_path=t.filename,
+                    missing_file_option='ignore',
+                    file_format=file_format,
+                )
+                t.assertIsNone(ys.get('doc'))
+                t.assertIsNone(ys.get('project.submodule.sub.key1'))
+                t.assertIsNone(ys.get('any.random.key'))


### PR DESCRIPTION
Major refactor of file-based configuration sources

* Adds IniSource, TomlSource, YamlSource — all implementing FileSourceP with a standardised constructor: file_path, file_format, config_env, missing_file_option
* All three support three file formats: environments, sections, flat
* Updates the public API (batconf.__init__) to export the new Source classes directly
* Deprecates IniConfig, TomlConfig, YamlConfig with DeprecationWarning on instantiation
* Updates docs (quickstart — TOML section added, YAML section updated to new format), migration guide, changelog
* Updates the example project to use the new API
* Adds integration tests per source + a cross-source parity test suite

Migration note for YAML users: YamlSource uses batconf: {default_env: env} at the top of the YAML file instead of default: env.
