### PR TITLE
Deprecate the 'module' keyword of .get methods

### DIFF
--- a/batconf/sources/_compat.py
+++ b/batconf/sources/_compat.py
@@ -7,6 +7,26 @@ the batconf.sources package. It is not part of the public API.
 import warnings
 
 
+def deprecated_module(path: str | None, module: str | None) -> str | None:
+    """Map the deprecated ``module`` keyword of ``.get()`` onto ``path``.
+
+    The ``module`` keyword argument is deprecated in v0.4.0 and removed in
+    v0.5.0; ``path`` is its replacement. When ``module`` is supplied a
+    ``DeprecationWarning`` is emitted and its value is used only if ``path``
+    was not also given.
+    """
+    if module is not None:
+        warnings.warn(
+            "the 'module' keyword argument to .get() is deprecated and will "
+            "be removed in v0.5.0; use 'path' instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        if path is None:
+            path = module
+    return path
+
+
 def make_deprecated_getattr(
     deprecated: dict[str, str],
     module_globals: dict,

--- a/batconf/sources/argparse.py
+++ b/batconf/sources/argparse.py
@@ -1,4 +1,5 @@
 from batconf.source import SourceInterface
+from batconf.sources._compat import deprecated_module
 
 from argparse import Namespace
 
@@ -25,9 +26,15 @@ class NamespaceConfig(SourceInterface):
     def __init__(self, namespace: Namespace) -> None:
         self._data = namespace
 
-    def get(self, key: str, module: str | None = None) -> str | None:
-        path = '.'.join((module, key)) if module else key
-        return getattr(self._data, path, None)
+    def get(
+        self,
+        key: str,
+        path: str | None = None,
+        module: str | None = None,
+    ) -> str | None:
+        path = deprecated_module(path, module)
+        attr = '.'.join((path, key)) if path else key
+        return getattr(self._data, attr, None)
 
     def __str__(self):
         return f'Namespace Source: {repr(self)}'

--- a/batconf/sources/dataclass.py
+++ b/batconf/sources/dataclass.py
@@ -9,6 +9,7 @@ from dataclasses import _MISSING_TYPE
 
 from ..source import SourceInterface
 from ..types import ConfigP, FieldP
+from ._compat import deprecated_module
 
 
 class DataclassConfig(SourceInterface):
@@ -31,21 +32,27 @@ class DataclassConfig(SourceInterface):
             else:
                 self._data[field.name] = cast(str, field.default)
 
-    def get(self, key: str, module: str | None = None) -> str | None:
-        if module:
-            path = module.split('.') + key.split('.')
+    def get(
+        self,
+        key: str,
+        path: str | None = None,
+        module: str | None = None,
+    ) -> str | None:
+        path = deprecated_module(path, module)
+        if path:
+            parts = path.split('.') + key.split('.')
             # remove the root module
             for m in self._root.split('.'):
-                if m == path[0]:
-                    path.pop(0)
+                if m == parts[0]:
+                    parts.pop(0)
         else:
-            path = key.split('.')
+            parts = key.split('.')
 
         # TODO: Needs a thorough review
         # The difficulty in typing this indicates some potential issues
         # like unexpected return values.
         conf: _DATA_DICT_TYPE | str | None = self._data
-        for k in path:
+        for k in parts:
             if (conf := conf.get(k)) is None:  # type: ignore
                 return conf
         return conf  # type: ignore

--- a/batconf/sources/env.py
+++ b/batconf/sources/env.py
@@ -1,6 +1,7 @@
 import os
 
 from ..source import SourceInterface
+from ._compat import deprecated_module
 
 
 class EnvConfig(SourceInterface):
@@ -24,8 +25,14 @@ class EnvConfig(SourceInterface):
     def __init__(self) -> None:
         pass
 
-    def get(self, key: str, module: str | None = None) -> str | None:
-        return os.getenv(self.env_name(key, module))
+    def get(
+        self,
+        key: str,
+        path: str | None = None,
+        module: str | None = None,
+    ) -> str | None:
+        path = deprecated_module(path, module)
+        return os.getenv(self.env_name(key, path))
 
     def env_name(self, key: str, module: str | None = None) -> str:
         if module:

--- a/batconf/sources/tests/_compat_test.py
+++ b/batconf/sources/tests/_compat_test.py
@@ -2,10 +2,46 @@ import warnings
 from unittest import TestCase
 from unittest.mock import sentinel
 
-from .._compat import make_deprecated_getattr
+from .._compat import make_deprecated_getattr, deprecated_module
 
 
 SRC = 'batconf.sources._compat'
+
+
+_MODULE_WARNING = (
+    "the 'module' keyword argument to .get() is deprecated and will "
+    "be removed in v0.5.0; use 'path' instead."
+)
+
+
+class DeprecatedModuleTests(TestCase):
+    """``deprecated_module`` maps the deprecated ``module`` keyword of
+    ``.get()`` onto its replacement ``path`` and warns when it is used."""
+
+    def test_no_module_returns_path_silently(t):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            result = deprecated_module(path='a.b', module=None)
+        t.assertEqual(result, 'a.b')
+        t.assertEqual(len(w), 0)
+
+    def test_module_only_returns_module_and_warns(t):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            result = deprecated_module(path=None, module='a.b')
+        t.assertEqual(result, 'a.b')
+        t.assertEqual(len(w), 1)
+        t.assertIs(w[0].category, DeprecationWarning)
+        t.assertEqual(_MODULE_WARNING, str(w[0].message))
+
+    def test_path_wins_when_both_supplied(t):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            result = deprecated_module(path='keep', module='ignore')
+        t.assertEqual(result, 'keep')
+        t.assertEqual(len(w), 1)
+        t.assertIs(w[0].category, DeprecationWarning)
+        t.assertEqual(_MODULE_WARNING, str(w[0].message))
 
 
 class MakeDeprecatedGetAttrTests(TestCase):

--- a/batconf/sources/tests/argparse_test.py
+++ b/batconf/sources/tests/argparse_test.py
@@ -23,8 +23,8 @@ class TestNamespaceConfig(TestCase):
         with t.subTest('missing value'):
             t.assertEqual(cs.get('missing'), None)
 
-        with t.subTest('module and key paths'):
-            t.assertEqual(cs.get('to.key', module='bat.module.path'), 'value')
+        with t.subTest('path and key paths'):
+            t.assertEqual(cs.get('to.key', path='bat.module.path'), 'value')
 
     def test___str__(t) -> None:
         cs = NamespaceConfig(Namespace())

--- a/batconf/sources/tests/dataclass_test.py
+++ b/batconf/sources/tests/dataclass_test.py
@@ -32,9 +32,9 @@ class TestDataclassConfig(TestCase):
         with t.subTest('single key'):
             t.assertEqual(conf.get('config_file'), './GlobalConfig.yaml')
 
-        with t.subTest('module value'):
+        with t.subTest('path value'):
             t.assertEqual(
-                conf.get('key', module=ConfigClass.__module__),
+                conf.get('key', path=ConfigClass.__module__),
                 'v_1',
             )
 
@@ -52,13 +52,13 @@ class TestDataclassConfig(TestCase):
                 'sub_v_1',
             )
 
-        with t.subTest('module and key paths'):
+        with t.subTest('path and key paths'):
             t.assertEqual(
-                conf.get('key', module=SubConfig.__module__),
+                conf.get('key', path=SubConfig.__module__),
                 'sub_v_1',
             )
             t.assertEqual(
-                conf.get('SubModule.key', module=ConfigClass.__module__),
+                conf.get('SubModule.key', path=ConfigClass.__module__),
                 'sub_v_1',
             )
 

--- a/batconf/sources/tests/env_test.py
+++ b/batconf/sources/tests/env_test.py
@@ -25,12 +25,12 @@ class TestEnvConfig(TestCase):
         with t.subTest('missing value'):
             t.assertEqual(conf.get('remote_host'), None)
 
-        with t.subTest('module value'):
-            t.assertEqual(conf.get('key', module='bat.module'), 'value')
+        with t.subTest('path value'):
+            t.assertEqual(conf.get('key', path='bat.module'), 'value')
 
-        with t.subTest('module and key paths'):
+        with t.subTest('path and key paths'):
             t.assertEqual(
-                conf.get('to.key', module='bat.module.path'), 'value2'
+                conf.get('to.key', path='bat.module.path'), 'value2'
             )
 
     def test_env_name(t):

--- a/docs/decisions/0002-get-path-parameter.md
+++ b/docs/decisions/0002-get-path-parameter.md
@@ -1,0 +1,119 @@
+# ADR 0002 — Standardize `.get()` on `path`; deprecate the `module` keyword
+
+Date: 2026-06-03
+Status: Proposed
+Branch: feature/get-name-resolution
+Issue: #3
+
+## Context
+
+Every configuration source implements
+`get(self, key, <namespace>) -> str | None`, where the second argument is the
+dotted namespace the key lives under. The canonical interface,
+`SourceInterfaceP` (`batconf/sources/types.py`), names that argument **`path`**.
+The concrete sources disagree:
+
+- **`path`** (matches the Protocol): `SourceList`, the `SourceInterface` ABC,
+  `IniSource`, `TomlSource`, `YamlSource`
+- **`module`** (diverges): `DataclassConfig`,
+  `NamespaceConfig`/`NamespaceSource`, `EnvConfig`/`EnvSource`,
+  `CliArgsConfig` (deprecated), and the legacy `YamlConfig` (deprecated)
+
+The name `module` is a historical artifact: namespaces were originally derived
+from a config class's `__module__`. They are now arbitrary dotted paths, so
+`path` describes the argument accurately and `module` is misleading. The split
+also means a caller cannot rely on one keyword name across sources.
+
+Issue #3 originally proposed going further — removing the second argument
+entirely and folding it into the `key` as a single dotted lookup,
+`get("project.database.host")`. That is **rejected** here: every source would
+then have to split, re-join, and strip the root namespace from one string
+(`DataclassConfig` already carries asymmetric root-strip logic between its two
+branches), pushing string-math into each implementation. Keeping an explicit
+`path` channel is simpler and keeps the namespace separate from the key.
+
+## Decision
+
+`path` is the one canonical second parameter for every source `.get()`.
+
+Three **live** sources currently expose `module`: `DataclassConfig`,
+`NamespaceConfig`/`NamespaceSource`, and `EnvConfig`/`EnvSource`. Each renames
+the parameter to `path` and accepts `module` as a **deprecated optional
+argument** for one release cycle:
+
+```python
+def get(self, key: str, path: str | None = None, module: str | None = None):
+    path = deprecated_module(path, module)
+    ...
+```
+
+`module` is a plain trailing optional argument, not keyword-only (`*, module`):
+nothing passes a third positional argument, so the marker would buy nothing.
+
+A shared helper, `deprecated_module(path, module)` in
+`batconf/sources/_compat.py`, emits the warning — one message, one v0.5.0
+removal point — and falls back to `module` only when `path` was not given.
+
+The two **already-deprecated** classes that also expose `module` —
+`CliArgsConfig` and the legacy `YamlConfig` — are left untouched. Each already
+emits a `DeprecationWarning` before `.get()` is ever reached (`YamlConfig` at
+import via the ADR 0003 module-`__getattr__` mechanism; `CliArgsConfig` at
+construction), and both are removed in v0.5.0. Adding a second
+`module`-keyword warning to their `.get()` would be redundant noise on names
+that are disappearing anyway.
+
+The six sources already on `path` are untouched. The `module` keyword is
+removed entirely in **v0.5.0**, at which point every live signature is
+`get(self, key, path=None)`.
+
+## Options considered
+
+### Deprecated `module` argument on the 3 live diverging sources (chosen)
+
+- Smallest diff; only the live sources that misnamed the argument change,
+  and already-deprecated classes are left alone [pro]
+- Positional 2nd argument is `path` everywhere immediately [pro]
+- Deprecated `module` keyword stays visible to mypy and IDEs [pro]
+- No string-math added to any source [pro]
+- Signatures are not byte-identical until v0.5.0 — the 3 live sources carry
+  an extra optional `module` argument during the deprecation cycle [con]
+
+### `module` keyword-only on all sources
+
+- Byte-identical signatures across every source [pro]
+- `module=` warns no matter which source is called [pro]
+- Adds a deprecated argument to sources that never advertised `module`,
+  for no caller benefit [con]
+- Larger diff [con]
+
+### Absorb `module` via `**kwargs`
+
+- Cleanest visible signature, `(key, path)` [pro]
+- Deprecated argument is invisible to introspection and autocomplete [con]
+- Weaker typing [con]
+
+### Collapse into a single dotted `key` (Issue #3 as written)
+
+- One argument total [pro]
+- Forces split / re-join / root-strip string-math into every source [con]
+- More code and more edge cases per source [con]
+
+## Consequences
+
+- Passing `module=` to `EnvSource`, `NamespaceSource`, or `DataclassConfig`
+  `.get()` emits `DeprecationWarning`; passing `path=` or the positional 2nd
+  argument does not warn.
+- `CliArgsConfig` and `YamlConfig` `.get()` keep their `module` parameter
+  silently — both classes already warn elsewhere and are removed in v0.5.0.
+- Tests that call `.get(..., module=...)` on the live sources (`env_test`,
+  `dataclass_test`, `argparse_test`) move to `path=` or assert the warning.
+  The deprecated-class tests (`args_test`, `yaml_test`) are unaffected.
+- `SourceInterfaceP` is unchanged — it already declares `path`. The Protocol
+  intentionally omits a default value: downstream implementors may require
+  `path` explicitly, and adding a default to the Protocol would cause a mypy
+  error on those implementations. The asymmetry is harmless — an
+  implementation with `path=None` satisfies a Protocol that marks `path`
+  required, but not the reverse.
+- v0.5.0 removes the `module` keyword and the helper, leaving
+  `get(self, key, path=None)` on every live source. Tracked as a follow-up to
+  Issue #3.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -19,3 +19,4 @@ Statuses: `Proposed → Accepted → Deprecated / Superseded by NNNN`
 | ---------------------------------------------- | ------------------------------ | -------- |
 | [0000](0000-foundational/)                     | Foundational decisions (8 decisions) | Accepted |
 | [0001](0001-file-source-classes/)              | FileSource class refactor (4 decisions) | Proposed |
+| [0002](0002-get-path-parameter.md)             | Standardize `.get()` on `path`; deprecate `module` | Proposed |

--- a/tests/integration/deprecated_module_param_test.py
+++ b/tests/integration/deprecated_module_param_test.py
@@ -1,0 +1,75 @@
+"""The ``module`` keyword argument to ``Source.get()`` is deprecated.
+
+``path`` replaces it (ADR 0002, issue #3). Until removal in v0.5.0, passing
+``module=`` must still resolve the same value as ``path=`` but emit a
+``DeprecationWarning``. This is the highest-level, outside-in specification:
+it exercises the deprecation through the public source classes exactly as a
+user would, independent of how any one source resolves a namespace.
+"""
+import warnings
+from argparse import Namespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from batconf import EnvSource, NamespaceSource
+from batconf.sources.dataclass import DataclassConfig
+
+
+_MODULE_WARNING = (
+    "the 'module' keyword argument to .get() is deprecated and will "
+    "be removed in v0.5.0; use 'path' instead."
+)
+
+
+class DeprecatedModuleParameterTests(TestCase):
+    def _assert_parity_and_warning(t, source, key, namespace, expected):
+        """``module=namespace`` resolves ``expected`` and warns;
+        ``path=namespace`` resolves the same value without warning."""
+        with t.subTest('module= resolves the value and warns'):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter('always')
+                via_module = source.get(key, module=namespace)
+            t.assertEqual(via_module, expected)
+            deprecations = [
+                w for w in caught
+                if issubclass(w.category, DeprecationWarning)
+            ]
+            t.assertEqual(len(deprecations), 1)
+            t.assertEqual(_MODULE_WARNING, str(deprecations[0].message))
+
+        with t.subTest('path= resolves the same value, no warning'):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter('always')
+                via_path = source.get(key, path=namespace)
+            t.assertEqual(via_path, expected)
+            t.assertEqual(
+                [w for w in caught
+                 if issubclass(w.category, DeprecationWarning)],
+                [],
+            )
+
+    @patch.dict('batconf.sources.env.os.environ', {'BAT_MODULE_KEY': 'value'})
+    def test_env_source(t):
+        t._assert_parity_and_warning(
+            EnvSource(), key='key', namespace='bat.module', expected='value'
+        )
+
+    def test_namespace_source(t):
+        ns = Namespace()
+        setattr(ns, 'bat.module.key', 'value')
+        t._assert_parity_and_warning(
+            NamespaceSource(ns), key='key', namespace='bat.module',
+            expected='value',
+        )
+
+    def test_dataclass_source(t):
+        from dataclasses import dataclass
+
+        @dataclass
+        class Config:
+            key: str = 'value'
+
+        source = DataclassConfig(Config, path='bat.module')
+        t._assert_parity_and_warning(
+            source, key='key', namespace='bat.module', expected='value'
+        )


### PR DESCRIPTION
Standardize every live source's .get() second argument on `path` (the canonical name in SourceInterfaceP).
EnvConfig, NamespaceConfig, and DataclassConfig accept `module` as a deprecated argument that warns and maps to `path`; to be removed in v0.5.0.
Already-deprecated classes are left untouched.
See ADR 0002.

Fixes: #3