### PR TITLE
docs: correct v0.4.0 release notes and example config (pre-release fixes for #214)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ dependencies = [
 ### Breaking Changes
 
 * `batconf.sources.file.FileConfig` has been removed.
-  See the [migration guide](https://batconf.readthedocs.io/en/v0.4.0/migration.html)
+  See the [migration guide](https://batconf.readthedocs.io/en/stable/migration.html)
   for details.
 
 ## Architecture Decision Records

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -19,9 +19,22 @@ BatConf 0.x
 
 Breaking changes:
 
-* Remove ``batconf.sources.file.FileConfig``
-  (deprecated since 0.2.0 — use :class:`~batconf.sources.ini.IniConfig`
-  or :class:`~batconf.sources.yaml.YamlConfig` instead)
+* Remove ``batconf.sources.file.FileConfig`` (deprecated since 0.2.0).
+  ``FileConfig`` read YAML files only, so its replacement is
+  :class:`~batconf.sources.yaml.YamlSource`. The constructor keyword was
+  renamed: ``config_file_name=`` is now ``file_path=``. See the
+  :doc:`migration` guide.
+* The ``Proto``-suffixed type names (``ConfigProtocol``, ``FieldProtocol``
+  and ``SourceInterfaceProto``) have been **removed** from
+  :mod:`batconf.manager`, :mod:`batconf.source` and
+  :mod:`batconf.sources.dataclass` — importing them from those modules
+  raises ``ImportError``. Deprecated equivalents (including the new
+  ``SourceListProto``) live in :mod:`batconf.types`. See the
+  :doc:`migration` guide.
+* :class:`~batconf.source.SourceList` no longer subclasses
+  ``SourceInterface``, so ``isinstance``/``issubclass`` checks against
+  ``SourceInterface`` no longer match it; use
+  :class:`~batconf.types.SourceListP` for type annotations.
 
 Features:
 
@@ -32,17 +45,29 @@ Features:
 * Subscript access on :class:`~batconf.manager.Configuration`:
   ``cfg['key']`` is equivalent to ``cfg.key``
 * :class:`~batconf.sources.ini.IniSource` — standardised INI file source
-  implementing :class:`~batconf.sources.types.FileSourceP`;
-  replaces :class:`~batconf.sources.ini.IniConfig`
+  implementing :class:`~batconf.sources.types.FileSourceP`; the successor to
+  :class:`~batconf.sources.ini.IniConfig`. It is **not** a drop-in rename:
+  the parameters after ``file_path`` were reordered —
+  ``IniConfig(file_path, config_env, missing_file_option, file_format)``
+  became
+  ``IniSource(file_path, file_format, config_env, missing_file_option)`` —
+  so ``IniSource('cfg.ini', 'dev')`` raises
+  ``ValueError: Invalid file_format: dev``. Pass ``config_env=`` by keyword.
 * :class:`~batconf.sources.toml.TomlSource` — standardised TOML file source
-  implementing :class:`~batconf.sources.types.FileSourceP`;
-  replaces :class:`~batconf.sources.toml.TomlConfig`
+  implementing :class:`~batconf.sources.types.FileSourceP`; the successor to
+  :class:`~batconf.sources.toml.TomlConfig`, whose constructor signature it
+  keeps unchanged
 * :class:`~batconf.sources.yaml.YamlSource` — standardised YAML file source
-  implementing :class:`~batconf.sources.types.FileSourceP`;
-  replaces :class:`~batconf.sources.yaml.YamlConfig`
-* New top-level public API — ``Configuration``, ``SourceList``,
-  ``NamespaceSource``, ``EnvSource``, ``IniSource``, ``TomlSource``,
-  ``YamlSource`` are now importable directly from ``batconf``
+  implementing :class:`~batconf.sources.types.FileSourceP`; the successor to
+  :class:`~batconf.sources.yaml.YamlConfig`. It is **not** a drop-in rename:
+  ``config_file_name=`` became ``file_path=`` (the old keyword raises
+  ``TypeError``), ``enable_config_environments=False`` has no direct
+  counterpart and maps to ``file_format='sections'``, and ``.get()`` takes
+  ``path=`` where ``YamlConfig.get()`` took ``module=``
+* New top-level public API — ``Configuration``, ``ConfigSingleton``,
+  ``SourceList``, ``insert_source``, ``NamespaceSource``, ``Namespace``,
+  ``EnvSource``, ``IniSource``, ``TomlSource`` and ``YamlSource`` are now
+  importable directly from ``batconf``
 
 Deprecated:
 
@@ -55,12 +80,18 @@ Deprecated:
 * ``CliArgsConfig`` — use
   :class:`~batconf.sources.argparse.NamespaceConfig` (exported as
   ``NamespaceSource``) instead
-* The ``module`` argument to file sources is deprecated and will be
-  removed in a future release
-* Proto-suffixed type names now emit a ``DeprecationWarning`` and resolve
-  to their ``P``-suffixed equivalents: ``ConfigProtocol`` → ``ConfigP``,
-  ``FieldProtocol`` → ``FieldP``, ``SourceInterfaceProto`` →
-  ``SourceInterfaceP``, ``SourceListProto`` → ``SourceListP``
+* The ``module`` keyword argument to ``.get()`` is deprecated on
+  :class:`~batconf.sources.env.EnvConfig` (exported as ``EnvSource``),
+  :class:`~batconf.sources.argparse.NamespaceConfig` (exported as
+  ``NamespaceSource``) and
+  :class:`~batconf.sources.dataclass.DataclassConfig`; use ``path``
+  instead. It will be removed in v0.5.0. The new file sources
+  (``IniSource``, ``TomlSource``, ``YamlSource``) accept ``path`` only and
+  raise ``TypeError`` if given ``module``.
+* The ``Proto``-suffixed aliases in :mod:`batconf.types` emit a
+  ``DeprecationWarning``; use the ``P``-suffixed names. Everywhere else
+  these names were removed outright — see Breaking changes above.
+
 
 .. _v0.3.1:
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -11,14 +11,6 @@ All previous releases should still be available
 BatConf 0.x
 ==============
 
-.. only:: has_release_file
-
-    --------------------
-    Current pull request
-    --------------------
-
-    .. include:: ../RELEASE.rst
-
 .. _v0.4.0:
 
 ------------------

--- a/docs/source/migration.rst
+++ b/docs/source/migration.rst
@@ -10,9 +10,46 @@ v0.4.0
 ========================
 FileConfig Removed
 ========================
-``batconf.sources.file.FileConfig`` has been removed.
-Replace it with :class:`~batconf.sources.ini.IniSource` or
-:class:`~batconf.sources.yaml.YamlSource` as appropriate.
+``batconf.sources.file.FileConfig`` has been removed. It read YAML files
+only, so its replacement is :class:`~batconf.sources.yaml.YamlSource`.
+The constructor keyword ``config_file_name`` was renamed to ``file_path``,
+so the obvious swap raises
+``TypeError: unexpected keyword argument 'config_file_name'``:
+
+.. code-block:: python
+
+    # old
+    from batconf.sources.file import FileConfig
+
+    source = FileConfig(config_file_name='config.yaml')
+
+    # new
+    from batconf import YamlSource
+
+    source = YamlSource(file_path='config.yaml')
+
+``FileConfig`` selected the active environment from the file's top-level
+``default`` key. ``YamlSource`` defaults to ``file_format='environments'``,
+which reads it from ``batconf.default_env`` instead, so the file itself
+needs updating:
+
+.. code-block:: yaml
+    :caption: config.yaml
+
+    # old
+    default: dev
+
+    # new
+    batconf:
+      default_env: dev
+
+    dev:
+      yourproject:
+        client:
+          api_key: example_api_key
+
+``FileConfig.get()`` took a ``module`` keyword; ``YamlSource.get()`` takes
+``path``.
 
 ========================
 New Public API
@@ -36,10 +73,13 @@ Old submodule imports still work but the top-level names are now preferred:
     # old
     from batconf.sources.argparse import NamespaceConfig, Namespace
     from batconf.sources.env import EnvConfig
-    from batconf.sources.ini import IniConfig
 
     # new
-    from batconf import NamespaceSource, Namespace, EnvSource, IniSource
+    from batconf import NamespaceSource, Namespace, EnvSource
+
+``IniConfig``, ``TomlConfig`` and ``YamlConfig`` still import too, but they
+are deprecated and emit a ``DeprecationWarning`` on import — see
+`Deprecations`_ below for their replacements.
 
 ========================
 ConfigSingleton
@@ -78,13 +118,52 @@ will be removed in a future release. Update your imports:
     from batconf.sources.yaml import YamlConfig  # YamlSource
     from batconf.sources.args import CliArgsConfig  # NamespaceConfig / NamespaceSource
 
-The ``module`` argument to file sources is also deprecated.
+The ``module`` keyword argument to ``.get()`` is also deprecated, on
+``EnvSource`` (``batconf.sources.env.EnvConfig``), ``NamespaceSource``
+(``batconf.sources.argparse.NamespaceConfig``) and
+``batconf.sources.dataclass.DataclassConfig``. It will be removed in
+v0.5.0; use ``path`` instead:
 
-Proto-suffixed type names now resolve to their ``P``-suffixed
-equivalents (``ConfigProtocol`` → ``ConfigP``, ``FieldProtocol`` →
-``FieldP``, ``SourceInterfaceProto`` → ``SourceInterfaceP``,
-``SourceListProto`` → ``SourceListP``). Prefer the ``P`` names; see
-:mod:`batconf.types`.
+.. code-block:: python
+
+    # old
+    EnvSource().get('api_key', module='project.client')
+
+    # new
+    EnvSource().get('api_key', path='project.client')
+
+The file sources ``IniSource``, ``TomlSource`` and ``YamlSource`` accept
+``path`` only and raise ``TypeError`` if given ``module``.
+
+The ``Proto``-suffixed type names were removed outright from the modules
+that used to export them, so update those imports:
+
+.. code-block:: python
+
+    # old — each of these now raises ImportError
+    from batconf.manager import ConfigProtocol, FieldProtocol
+    from batconf.source import SourceInterfaceProto
+    from batconf.sources.dataclass import ConfigProtocol, FieldProtocol
+
+    # new
+    from batconf.types import ConfigP, FieldP, SourceInterfaceP
+
+:mod:`batconf.types` is the one place the old names still resolve, and
+they emit a ``DeprecationWarning`` when they do. The full mapping, from
+the removed name to its ``batconf.types`` alias to the ``P``-suffixed name
+to prefer:
+
+* ``batconf.manager.ConfigProtocol``,
+  ``batconf.sources.dataclass.ConfigProtocol``
+  → ``batconf.types.ConfigProtocol`` → ``batconf.types.ConfigP``
+* ``batconf.manager.FieldProtocol``,
+  ``batconf.sources.dataclass.FieldProtocol``
+  → ``batconf.types.FieldProtocol`` → ``batconf.types.FieldP``
+* ``batconf.source.SourceInterfaceProto``
+  → ``batconf.types.SourceInterfaceProto``
+  → ``batconf.types.SourceInterfaceP``
+* ``SourceListProto`` (new in 0.4.0, ``batconf.types`` only)
+  → ``batconf.types.SourceListP``
 
 
 ******

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -1,5 +1,6 @@
 
-default: example
+batconf:
+    default_env: example
 
 example:
     remote_host:


### PR DESCRIPTION
A few quick things to cleanup before we release v0.4.0

---
:robot: AI text below :robot:

Fixes the doc problems found reviewing #214 so the release notes match the actual 0.4.0 code. Every corrected claim was verified by executing it; details in the commit messages.

- changelog.rst: Proto-name removal and SourceList base-class change are breaking, not deprecations; FileConfig replacement is YamlSource (was pointing at deprecated classes); module-arg deprecation names the right sources and the concrete v0.5.0 removal; top-level API list completed to all 10 exports.
- migration.rst: same corrections, plus an old→new FileConfig code sample (config_file_name= → file_path=).
- example.config.yaml: rewritten to the new YamlSource environments format (old layout raises KeyError: 'batconf').
- Cherry-pick 476f88a: remove dead RELEASE.rst include. Fixes #56.
- README: migration link pinned to /en/v0.4.0/ → /en/stable/ (feeds PyPI long_description).

Verification: docs build clean of the RELEASE.rst warning; tests and lint green.

Reviewer notes: merge before #214, then rebase release/v0.4.0 onto main. KEYS/SECURITY.md intentionally excluded — separate PR.