### PR TITLE
Docs: release signing steps

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yml
+++ b/.github/ISSUE_TEMPLATE/release.yml
@@ -17,6 +17,7 @@ body:
     id: release-tasks
     attributes:
       label: ToDo
+      description: "Quick reminders — full commands and details in the [release guide](https://batconf.readthedocs.io/en/latest/publishing.html)."
       options:
         - label: Update version in pyproject.toml (remove the +dev suffix)
         - label: Change release notes date from TBD to today's date
@@ -24,8 +25,10 @@ body:
         - label: 'Commit the release changes (message: `Release version X.Y.Z` / blank line / `Fixes: #<release ticket number>`)'
         - label: Add a commit bumping the version to VERSION_NUMBER+dev
         - label: Open a release PR, get it reviewed, and merge (merge commit — preserves the signed release commit)
-        - label: Tag the release commit with a signed tag (`git tag -s`) and verify (`git tag -v`)
-        - label: Build, run `twine check`, and GPG-sign the artifacts (`gpg --detach-sign --armor dist/*`)
+        - label: Tag the release commit with a signed tag (`git tag -s -u <YOUR_FINGERPRINT>`) and verify (`git tag -v`)
+        - label: Build and run `twine check`
         - label: Publish to test.pypi and verify
-        - label: Publish to pypi and verify
+        - label: GPG-sign the artifacts (`gpg -u <YOUR_FINGERPRINT> --detach-sign --armor`) — no rebuilds after signing
+        - label: Verify the artifact and tag signatures (`gpg --verify`, `git tag -v`)
+        - label: Publish the same dist files to pypi and verify
         - label: Create the [GitHub release](https://github.com/lundybernard/batconf/releases) with the signed artifacts (.asc) attached

--- a/.github/ISSUE_TEMPLATE/release.yml
+++ b/.github/ISSUE_TEMPLATE/release.yml
@@ -32,3 +32,4 @@ body:
         - label: Verify the artifact and tag signatures (`gpg --verify`, `git tag -v`)
         - label: Publish the same dist files to pypi and verify
         - label: Create the [GitHub release](https://github.com/lundybernard/batconf/releases) with the signed artifacts (.asc) attached
+        - label: Activate the new version on ReadTheDocs and confirm `stable` serves it

--- a/docs/source/publishing.rst
+++ b/docs/source/publishing.rst
@@ -151,3 +151,12 @@ Steps
     `github releases <https://github.com/lundybernard/batconf/releases>`_
   * Upload the build artifacts (``dist/*.tar.gz``, ``dist/*.whl``) and their
     ``.asc`` signatures so users can verify downloads against the signing key.
+
+* Activate the new version on ReadTheDocs
+
+  * On the ReadTheDocs dashboard (Versions), find or add the ``v{{X.Y.Z}}``
+    tag and enable its **Active** toggle.
+  * Confirm `stable <https://batconf.readthedocs.io/en/stable/>`_ serves the
+    new release — ``stable`` tracks the highest activated version tag — and
+    that `migration.html <https://batconf.readthedocs.io/en/stable/migration.html>`_
+    resolves (the PyPI README links to it).

--- a/docs/source/publishing.rst
+++ b/docs/source/publishing.rst
@@ -10,6 +10,17 @@ Each maintainer sets up their own GPG signing key before their first release.
 See :doc:`signing` for the one-time key generation, backup, and publishing
 steps.
 
+Every signing command below names your key explicitly with ``-u``. Never rely
+on the gpg default key: without ``-u``, gpg signs with whichever secret key it
+considers default, which may not be the key listed for you in
+:gh-file:`docs/SECURITY.md <docs/SECURITY.md>` — the resulting signature then
+fails verification against the project's trust anchor
+(:gh-file:`KEYS <KEYS>`). Throughout, ``{{FINGERPRINT}}`` is your
+primary-key fingerprint exactly as listed in your row of the
+authorized-signers table in :gh-file:`docs/SECURITY.md <docs/SECURITY.md>`
+(40 hex characters, no spaces — the ``$FPR`` from :doc:`signing`). Naming the
+primary key is enough; gpg selects your newest signing subkey automatically.
+
 Steps
 -----
 
@@ -66,13 +77,14 @@ Steps
     * Because the merge preserves SHAs, this hash matches the release
       commit on your local release branch.
 
-  * Tag the release. The version tag is GPG-signed (``-s``):
+  * Tag the release. The version tag is GPG-signed (``-s``) with your key
+    named explicitly (``-u``):
 
     .. code-block:: bash
 
        git tag -f release {{commit#}}
        git tag -f stable {{commit#}}
-       git tag -s v{{X.Y.Z}} {{commit#}} -m "Release vX.Y.Z"
+       git tag -s -u {{FINGERPRINT}} v{{X.Y.Z}} {{commit#}} -m "Release vX.Y.Z"
        # force-push only the moving tags; push the signed version tag
        # without --force so a published, immutable tag is never clobbered
        git push origin release stable --force
@@ -85,18 +97,51 @@ Steps
   * Checkout release ``git checkout release``
   * Build the package: ``hatch build``
   * Check the artifacts: ``twine check dist/*``
-  * Sign the artifacts (detached, armored):
-    ``gpg --detach-sign --armor dist/*``
-
-    * Produces a ``.asc`` signature next to each sdist/wheel.
-    * PyPI no longer accepts signature uploads, so these are published
-      on the GitHub Release (below), not via twine.
-
   * Publish to test pypi:
     ``twine upload --verbose --repository testpypi dist/*.tar.gz dist/*.whl``
   * Verify the release looks good on
     `test.pypi <https://test.pypi.org/project/batconf/>`_
-  * Publish to pypi:
+
+  * Sign the artifacts (detached, armored), naming your key explicitly:
+
+    .. code-block:: bash
+
+       gpg -u {{FINGERPRINT}} --detach-sign --armor dist/batconf-X.Y.Z.tar.gz
+       gpg -u {{FINGERPRINT}} --detach-sign --armor dist/batconf-X.Y.Z-py3-none-any.whl
+
+    * Produces a ``.asc`` signature next to each sdist/wheel.
+    * PyPI no longer accepts signature uploads, so these are published
+      on the GitHub Release (below), not via twine.
+    * Sign each filename explicitly rather than ``dist/*``: the glob also
+      matches leftover ``.asc`` files on a re-sign, so gpg prompts to
+      overwrite them (a missed prompt silently keeps a stale signature)
+      and signs the ``.asc`` files too.
+
+    .. warning::
+
+       Do **not** rebuild — ``hatch build``, ``python -m build``, or any
+       other build — after signing, or after the test.pypi upload. Build
+       output is not byte-reproducible, so a rebuild produces new bytes:
+       every ``.asc`` becomes invalid, and the files published to PyPI would
+       no longer be the ones you verified. Sign and publish the *same*
+       ``dist/`` files you uploaded to test.pypi. If ``dist/`` was
+       regenerated anyway, re-download the canonical files from test.pypi,
+       re-sign them, and re-verify.
+
+  * Verify the signatures **before** publishing to real pypi:
+
+    .. code-block:: bash
+
+       gpg --verify dist/batconf-X.Y.Z.tar.gz.asc dist/batconf-X.Y.Z.tar.gz
+       gpg --verify dist/batconf-X.Y.Z-py3-none-any.whl.asc \
+           dist/batconf-X.Y.Z-py3-none-any.whl
+       git tag -v v{{X.Y.Z}}
+
+    * Each must report ``Good signature`` **and** a primary key fingerprint
+      matching your row in :gh-file:`docs/SECURITY.md <docs/SECURITY.md>`.
+      A good signature from an unexpected key is a failure, not a pass.
+
+  * Publish the **same** files to pypi:
     ``twine upload --verbose --repository pypi dist/*.tar.gz dist/*.whl``
   * Verify the release on `pypi <https://pypi.org/project/batconf/>`_
 


### PR DESCRIPTION
Updated the release ticket template and release process docs with some items we found lacking during the last release.