### PR TITLE
ci: set persist-credentials false on all checkouts

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -21,6 +21,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           # Fetch the commit SHA
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Clean Jupyter Notebooks
         uses: ResearchSoftwareActions/EnsureCleanNotebooksAction@e22cb52580930a21c3121a44c9e67fa37e149121 # v1.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: prefix-dev/setup-pixi@f00437f565399d418b0acc85936d12c1fb668347 # v0.10.1
         with:
@@ -80,6 +82,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: prefix-dev/setup-pixi@f00437f565399d418b0acc85936d12c1fb668347 # v0.10.1
         with:
@@ -94,6 +98,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: prefix-dev/setup-pixi@f00437f565399d418b0acc85936d12c1fb668347 # v0.10.1
         with:


### PR DESCRIPTION
Zizmor flags credential persistence on every actions/checkout step. No workflow pushes commits, so no step needs the persisted token.

Assisted-by: claude-code:claude-fable-5